### PR TITLE
feat: measure client latency

### DIFF
--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useLatency } from './net/use-latency';
 import { EntityStatus } from './ui/entity-status';
 import { LogConsole, LogEntry } from './ui/log-console';
 
@@ -14,6 +15,7 @@ export function App() {
   const [inLogs, setInLogs] = useState<LogEntry[]>([]);
   const [outLogs, setOutLogs] = useState<LogEntry[]>([]);
   const [systemLogs, setSystemLogs] = useState<LogEntry[]>([]);
+  const latency = useLatency(socket);
 
   const log = (
     setter: React.Dispatch<React.SetStateAction<LogEntry[]>>,
@@ -63,7 +65,14 @@ export function App() {
           Connect
         </button>
       </div>
-      {socket && <p className="text-green-700">Connected</p>}
+      {socket && (
+        <div>
+          <p className="text-green-700">Connected</p>
+          {latency !== null && (
+            <p className="text-sm text-gray-700">Latency: {latency} ms</p>
+          )}
+        </div>
+      )}
       {snapshot && snapshot.entities[0] && (
         <div className="mt-4">
           <EntityStatus

--- a/apps/client/src/net/use-latency.ts
+++ b/apps/client/src/net/use-latency.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useLatency(socket: WebSocket | null, intervalMs = 2000) {
+  const [rtt, setRtt] = useState<number | null>(null);
+  const pending = useRef<Map<number, number>>(new Map());
+
+  useEffect(() => {
+    if (!socket) {
+      setRtt(null);
+      return;
+    }
+
+    const handleMessage = (ev: MessageEvent) => {
+      try {
+        const msg = JSON.parse(ev.data) as { t: string; nonce?: number };
+        if (msg.t === 'Pong' && typeof msg.nonce === 'number') {
+          const sent = pending.current.get(msg.nonce);
+          if (sent !== undefined) {
+            setRtt(Date.now() - sent);
+            pending.current.delete(msg.nonce);
+          }
+        }
+      } catch {
+        // ignore parsing errors
+      }
+    };
+
+    socket.addEventListener('message', handleMessage);
+
+    const timer = setInterval(() => {
+      if (socket.readyState === WebSocket.OPEN) {
+        const nonce = Date.now();
+        pending.current.set(nonce, nonce);
+        socket.send(JSON.stringify({ t: 'Ping', nonce }));
+      }
+    }, intervalMs);
+
+    return () => {
+      clearInterval(timer);
+      socket.removeEventListener('message', handleMessage);
+      pending.current.clear();
+    };
+  }, [socket, intervalMs]);
+
+  return rtt;
+}
+


### PR DESCRIPTION
## Summary
- add `useLatency` hook to periodically ping server and compute round-trip time
- show current latency in client app

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8e8f3fd4c8328b11da9dc261a71b6