### PR TITLE
test: add movement and hydration system tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ A **3D View** button switches to a Three.js scene where the map is rendered as v
 
 The server also serves a lightweight dashboard at http://localhost:3000/ui for viewing state, launching simple game actions, and displaying the same isometric map renderer used by the client. A **Redraw Map** button requests the latest room state from the server and refreshes the view.
 
+## Testing
+
+Run the server unit tests, including the ECS system specs, with:
+
+```bash
+pnpm --filter @snail/server test
+```
+
+To execute the full test suite across all packages:
+
+```bash
+pnpm test
+```
+
 ## Documentation
 
 - [CHANGELOG](CHANGELOG.md)

--- a/apps/server/src/ecs/systems/hydration.system.spec.ts
+++ b/apps/server/src/ecs/systems/hydration.system.spec.ts
@@ -1,0 +1,36 @@
+import { createWorld, addEntity, addComponent } from 'bitecs';
+import { Hydration, Velocity } from '../components';
+import { hydrationSystem } from './hydration.system';
+
+describe('hydrationSystem', () => {
+  function setup(hydration: number, dx: number, dy: number) {
+    const world = createWorld();
+    const eid = addEntity(world);
+    addComponent(world, Hydration, eid);
+    addComponent(world, Velocity, eid);
+    Hydration.value[eid] = hydration;
+    Velocity.dx[eid] = dx;
+    Velocity.dy[eid] = dy;
+    return { world, eid };
+  }
+
+  it('decreases hydration when entity moves', () => {
+    const { world, eid } = setup(10, 1, 0);
+    hydrationSystem(world);
+    expect(Hydration.value[eid]).toBe(9);
+  });
+
+  it('keeps hydration when stationary', () => {
+    const { world, eid } = setup(10, 0, 0);
+    hydrationSystem(world);
+    expect(Hydration.value[eid]).toBe(10);
+  });
+
+  it('does not drop hydration below zero', () => {
+    const { world, eid } = setup(1, 1, 1);
+    hydrationSystem(world);
+    hydrationSystem(world);
+    expect(Hydration.value[eid]).toBe(0);
+  });
+});
+

--- a/apps/server/src/ecs/systems/movement.system.spec.ts
+++ b/apps/server/src/ecs/systems/movement.system.spec.ts
@@ -1,0 +1,39 @@
+import { createWorld, addEntity, addComponent } from 'bitecs';
+import { Position, Velocity } from '../components';
+import { movementSystem } from './movement.system';
+
+describe('movementSystem', () => {
+  function setup(x: number, y: number, dx: number, dy: number) {
+    const world = createWorld();
+    const eid = addEntity(world);
+    addComponent(world, Position, eid);
+    addComponent(world, Velocity, eid);
+    Position.x[eid] = x;
+    Position.y[eid] = y;
+    Velocity.dx[eid] = dx;
+    Velocity.dy[eid] = dy;
+    return { world, eid };
+  }
+
+  it('updates position with positive velocity', () => {
+    const { world, eid } = setup(0, 0, 2, 3);
+    movementSystem(world);
+    expect(Position.x[eid]).toBe(2);
+    expect(Position.y[eid]).toBe(3);
+  });
+
+  it('handles negative velocities crossing boundaries', () => {
+    const { world, eid } = setup(1, 1, -2, -4);
+    movementSystem(world);
+    expect(Position.x[eid]).toBe(-1);
+    expect(Position.y[eid]).toBe(-3);
+  });
+
+  it('does not move when velocity is zero', () => {
+    const { world, eid } = setup(5, 5, 0, 0);
+    movementSystem(world);
+    expect(Position.x[eid]).toBe(5);
+    expect(Position.y[eid]).toBe(5);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add movement system tests covering velocity and boundary scenarios
- add hydration system tests for movement-based depletion
- document how to run tests in README

## Testing
- `CI=true pnpm --filter @snail/server test`


------
https://chatgpt.com/codex/tasks/task_e_68b9bd8d7a34832889894c3aa84869ad