### PR TITLE
Add terrain-aware movement and hydration systems

### DIFF
--- a/apps/server/src/ecs/components.ts
+++ b/apps/server/src/ecs/components.ts
@@ -3,10 +3,50 @@ import { defineComponent, Types } from 'bitecs';
 export const Position = defineComponent({ x: Types.f32, y: Types.f32 });
 export const Velocity = defineComponent({ dx: Types.f32, dy: Types.f32 });
 export const Hydration = defineComponent({ value: Types.f32 });
+export const Worker = defineComponent({
+  carry: Types.f32,
+  carry_capacity: Types.f32,
+  hydration_max: Types.f32,
+});
+export const Dead = defineComponent();
 
 export type WorldComponents = {
   position: typeof Position;
   velocity: typeof Velocity;
   hydration: typeof Hydration;
+  worker: typeof Worker;
+  dead: typeof Dead;
 };
+
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+
+function findParametersPath(): string {
+  const roots = [__dirname, process.cwd()];
+  for (const start of roots) {
+    for (let dir = start; ; ) {
+      const candidate = join(dir, 'config', 'parameters.json');
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+      const parent = dirname(dir);
+      if (parent === dir) {
+        break;
+      }
+      dir = parent;
+    }
+  }
+  throw new Error('parameters.json not found');
+}
+
+const paramsRaw = readFileSync(findParametersPath(), 'utf-8');
+const params = JSON.parse(paramsRaw) as {
+  unit_worker: { carry_capacity: number; hydration_max: number };
+};
+
+export function initWorker(eid: number) {
+  Worker.carry[eid] = 0;
+  Worker.carry_capacity[eid] = params.unit_worker.carry_capacity;
+  Worker.hydration_max[eid] = params.unit_worker.hydration_max;
+}
 

--- a/apps/server/src/ecs/systems/hydration.system.spec.ts
+++ b/apps/server/src/ecs/systems/hydration.system.spec.ts
@@ -1,36 +1,71 @@
-import { createWorld, addEntity, addComponent } from 'bitecs';
-import { Hydration, Velocity } from '../components';
+import { createWorld, addEntity, addComponent, hasComponent } from 'bitecs';
+import { Hydration, Velocity, Position, Worker, Dead, initWorker } from '../components';
 import { hydrationSystem } from './hydration.system';
+import type {
+  MapDef,
+  WaterLayer,
+  GrassLayer,
+  Structure,
+  TerrainType,
+} from '@snail/protocol';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const params = JSON.parse(
+  readFileSync(join(__dirname, '../../../config/parameters.json'), 'utf-8')
+);
+
+function makeMap(terrain: string, water?: number): MapDef {
+  return {
+    width: 1,
+    height: 1,
+    version: 1,
+    moisture: 0,
+    tiles: [
+      {
+        terrain: terrain as unknown as TerrainType,
+        water: 'None' as WaterLayer,
+        grass: 'None' as GrassLayer,
+        structure: 'None' as Structure,
+        resources: water ? { water } : undefined,
+      },
+    ],
+  } as unknown as MapDef;
+}
 
 describe('hydrationSystem', () => {
-  function setup(hydration: number, dx: number, dy: number) {
+  function setup(map: MapDef, hydration: number, dx: number, dy: number) {
     const world = createWorld();
     const eid = addEntity(world);
     addComponent(world, Hydration, eid);
     addComponent(world, Velocity, eid);
+    addComponent(world, Position, eid);
+    addComponent(world, Worker, eid);
+    initWorker(eid);
     Hydration.value[eid] = hydration;
+    Position.x[eid] = 0;
+    Position.y[eid] = 0;
     Velocity.dx[eid] = dx;
     Velocity.dy[eid] = dy;
-    return { world, eid };
+    return { world, eid, map };
   }
 
-  it('decreases hydration when entity moves', () => {
-    const { world, eid } = setup(10, 1, 0);
-    hydrationSystem(world);
-    expect(Hydration.value[eid]).toBe(9);
+  it('reduces hydration based on terrain cost', () => {
+    const { world, eid, map } = setup(makeMap('gravel'), 5, 1, 0);
+    hydrationSystem(world, map, params);
+    expect(Hydration.value[eid]).toBeCloseTo(4.8);
   });
 
-  it('keeps hydration when stationary', () => {
-    const { world, eid } = setup(10, 0, 0);
-    hydrationSystem(world);
-    expect(Hydration.value[eid]).toBe(10);
+  it('refills hydration at water node', () => {
+    const { world, eid, map } = setup(makeMap('grass', 10), 3, 0, 0);
+    hydrationSystem(world, map, params);
+    expect(Hydration.value[eid]).toBe(Worker.hydration_max[eid]);
   });
 
-  it('does not drop hydration below zero', () => {
-    const { world, eid } = setup(1, 1, 1);
-    hydrationSystem(world);
-    hydrationSystem(world);
-    expect(Hydration.value[eid]).toBe(0);
+  it('marks entity dead when hydration hits zero on hard terrain', () => {
+    const { world, eid, map } = setup(makeMap('sidewalk'), 0.1, 1, 0);
+    hydrationSystem(world, map, params);
+    expect(Hydration.value[eid]).toBeCloseTo(0);
+    expect(hasComponent(world, Dead, eid)).toBe(true);
   });
 });
-

--- a/apps/server/src/ecs/systems/hydration.system.ts
+++ b/apps/server/src/ecs/systems/hydration.system.ts
@@ -1,13 +1,31 @@
-import { IWorld, defineQuery } from 'bitecs';
-import { Hydration, Velocity } from '../components';
+import { IWorld, defineQuery, addComponent } from 'bitecs';
+import { Hydration, Velocity, Position, Worker, Dead } from '../components';
+import { MapDef } from '@snail/protocol';
+import { terrainAt, isWaterNode } from '../../game/terrain';
 
-const hydrateQuery = defineQuery([Hydration, Velocity]);
+interface Params {
+  terrain: Record<string, { hydration_cost: number }>;
+}
 
-export function hydrationSystem(world: IWorld) {
+const hydrateQuery = defineQuery([Hydration, Velocity, Position, Worker]);
+
+export function hydrationSystem(world: IWorld, map: MapDef, params: Params) {
   const ents = hydrateQuery(world);
   for (const eid of ents) {
+    const x = Math.floor(Position.x[eid]);
+    const y = Math.floor(Position.y[eid]);
+    const terrain = terrainAt(map, x, y);
+    let value = Hydration.value[eid];
     if (Velocity.dx[eid] !== 0 || Velocity.dy[eid] !== 0) {
-      Hydration.value[eid] = Math.max(0, Hydration.value[eid] - 1);
+      const cost = params.terrain?.[terrain ?? '']?.hydration_cost ?? 0;
+      value = Math.max(0, value - cost);
+    }
+    if (isWaterNode(map, x, y)) {
+      value = Worker.hydration_max[eid];
+    }
+    Hydration.value[eid] = value;
+    if (value <= 0 && (terrain === 'gravel' || terrain === 'sidewalk')) {
+      addComponent(world, Dead, eid);
     }
   }
   return world;

--- a/apps/server/src/ecs/systems/movement.system.spec.ts
+++ b/apps/server/src/ecs/systems/movement.system.spec.ts
@@ -1,39 +1,65 @@
 import { createWorld, addEntity, addComponent } from 'bitecs';
 import { Position, Velocity } from '../components';
 import { movementSystem } from './movement.system';
+import type {
+  MapDef,
+  WaterLayer,
+  GrassLayer,
+  Structure,
+  TerrainType,
+} from '@snail/protocol';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const params = JSON.parse(
+  readFileSync(join(__dirname, '../../../config/parameters.json'), 'utf-8')
+);
+
+function makeMap(terrain: string): MapDef {
+  return {
+    width: 1,
+    height: 1,
+    version: 1,
+    moisture: 0,
+    tiles: [
+      {
+        terrain: terrain as unknown as TerrainType,
+        water: 'None' as WaterLayer,
+        grass: 'None' as GrassLayer,
+        structure: 'None' as Structure,
+      },
+    ],
+  } as unknown as MapDef;
+}
 
 describe('movementSystem', () => {
-  function setup(x: number, y: number, dx: number, dy: number) {
+  function setup(dx: number, dy: number) {
     const world = createWorld();
     const eid = addEntity(world);
     addComponent(world, Position, eid);
     addComponent(world, Velocity, eid);
-    Position.x[eid] = x;
-    Position.y[eid] = y;
+    Position.x[eid] = 0;
+    Position.y[eid] = 0;
     Velocity.dx[eid] = dx;
     Velocity.dy[eid] = dy;
     return { world, eid };
   }
 
-  it('updates position with positive velocity', () => {
-    const { world, eid } = setup(0, 0, 2, 3);
-    movementSystem(world);
-    expect(Position.x[eid]).toBe(2);
-    expect(Position.y[eid]).toBe(3);
+  it('scales movement by terrain base_speed', () => {
+    const map = makeMap('gravel');
+    const { world, eid } = setup(1, 0);
+    movementSystem(world, map, params);
+    expect(Position.x[eid]).toBeCloseTo(0.8); // gravel base_speed 0.8
   });
 
-  it('handles negative velocities crossing boundaries', () => {
-    const { world, eid } = setup(1, 1, -2, -4);
-    movementSystem(world);
-    expect(Position.x[eid]).toBe(-1);
-    expect(Position.y[eid]).toBe(-3);
-  });
-
-  it('does not move when velocity is zero', () => {
-    const { world, eid } = setup(5, 5, 0, 0);
-    movementSystem(world);
-    expect(Position.x[eid]).toBe(5);
-    expect(Position.y[eid]).toBe(5);
+  it('is slower on sidewalk than grass', () => {
+    const grassMap = makeMap('grass');
+    const sidewalkMap = makeMap('sidewalk');
+    const { world: w1, eid: e1 } = setup(1, 0);
+    const { world: w2, eid: e2 } = setup(1, 0);
+    movementSystem(w1, grassMap, params);
+    movementSystem(w2, sidewalkMap, params);
+    expect(Position.x[e1]).toBeCloseTo(1.0);
+    expect(Position.x[e2]).toBeCloseTo(0.6);
   });
 });
-

--- a/apps/server/src/ecs/systems/movement.system.ts
+++ b/apps/server/src/ecs/systems/movement.system.ts
@@ -1,13 +1,21 @@
 import { IWorld, defineQuery } from 'bitecs';
 import { Position, Velocity } from '../components';
+import { MapDef } from '@snail/protocol';
+import { terrainAt } from '../../game/terrain';
+
+interface Params {
+  terrain: Record<string, { base_speed: number }>;
+}
 
 const moveQuery = defineQuery([Position, Velocity]);
 
-export function movementSystem(world: IWorld) {
+export function movementSystem(world: IWorld, map: MapDef, params: Params) {
   const ents = moveQuery(world);
   for (const eid of ents) {
-    Position.x[eid] += Velocity.dx[eid];
-    Position.y[eid] += Velocity.dy[eid];
+    const terrain = terrainAt(map, Math.floor(Position.x[eid]), Math.floor(Position.y[eid]));
+    const base = params.terrain?.[terrain ?? '']?.base_speed ?? 1;
+    Position.x[eid] += Velocity.dx[eid] * base;
+    Position.y[eid] += Velocity.dy[eid] * base;
   }
   return world;
 }

--- a/apps/server/src/ecs/world.ts
+++ b/apps/server/src/ecs/world.ts
@@ -1,11 +1,21 @@
 import { IWorld, addComponent, addEntity, createWorld } from 'bitecs';
-import { Hydration, Position, Velocity } from './components';
+import { Hydration, Position, Velocity, Worker, initWorker } from './components';
 import { movementSystem } from './systems/movement.system';
 import { hydrationSystem } from './systems/hydration.system';
+import { MapService } from '../game/map.service';
+import { MapDef } from '@snail/protocol';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+interface Params {
+  terrain: Record<string, { base_speed: number; hydration_cost: number }>;
+}
 
 export class World {
   private world: IWorld;
   private snail: number;
+  private map: MapDef;
+  private params: Params;
 
   constructor() {
     this.world = createWorld();
@@ -13,16 +23,23 @@ export class World {
     addComponent(this.world, Position, this.snail);
     addComponent(this.world, Velocity, this.snail);
     addComponent(this.world, Hydration, this.snail);
+    addComponent(this.world, Worker, this.snail);
+    initWorker(this.snail);
     Position.x[this.snail] = 0;
     Position.y[this.snail] = 0;
     Velocity.dx[this.snail] = 0;
     Velocity.dy[this.snail] = 0;
     Hydration.value[this.snail] = 100;
+    const svc = new MapService();
+    this.map = svc.load('test');
+    this.params = JSON.parse(
+      readFileSync(join(__dirname, '../../config/parameters.json'), 'utf-8')
+    ) as Params;
   }
 
   tick() {
-    movementSystem(this.world);
-    hydrationSystem(this.world);
+    movementSystem(this.world, this.map, this.params);
+    hydrationSystem(this.world, this.map, this.params);
   }
 
   snapshot() {

--- a/apps/server/src/game/terrain.ts
+++ b/apps/server/src/game/terrain.ts
@@ -1,0 +1,17 @@
+import { MapDef, Tile } from '@snail/protocol';
+
+export function tileAt(map: MapDef, x: number, y: number): Tile | undefined {
+  if (x < 0 || y < 0 || x >= map.width || y >= map.height) {
+    return undefined;
+  }
+  return map.tiles[y * map.width + x];
+}
+
+export function terrainAt(map: MapDef, x: number, y: number): string | undefined {
+  return tileAt(map, x, y)?.terrain as unknown as string | undefined;
+}
+
+export function isWaterNode(map: MapDef, x: number, y: number): boolean {
+  const tile = tileAt(map, x, y);
+  return (tile?.resources?.water ?? 0) > 0;
+}


### PR DESCRIPTION
## Summary
- add Worker and Dead components initialized from parameters
- scale movement and hydration costs using terrain values
- allow hydration refill at water tiles and mark entities dead when depleted
- provide terrain lookup utilities and corresponding tests

## Testing
- `pnpm --filter @snail/server lint`
- `pnpm --filter @snail/server test`

------
https://chatgpt.com/codex/tasks/task_e_68b9f8913108832889053e75ea19a6d0