### PR TITLE
feat(server): implement room room management

### DIFF
--- a/apps/server/src/game/room.service.spec.ts
+++ b/apps/server/src/game/room.service.spec.ts
@@ -1,0 +1,30 @@
+import { RoomService } from './room.service';
+
+describe('RoomService', () => {
+  it('creates rooms and tracks join/leave', () => {
+    const svc = new RoomService();
+    const room = svc.createRoom('r1');
+    expect(room.id).toBe('r1');
+    svc.joinRoom('r1', 'p1');
+    expect(svc.getRoom('r1')?.players.has('p1')).toBe(true);
+    svc.leaveRoom('r1', 'p1');
+    expect(svc.getRoom('r1')).toBeUndefined();
+  });
+
+  it('starts game when all players ready', () => {
+    jest.useFakeTimers();
+    const svc = new RoomService();
+    svc.createRoom('r1');
+    svc.joinRoom('r1', 'a');
+    svc.joinRoom('r1', 'b');
+    svc.setReady('r1', 'a', true);
+    expect(() => svc.startGame('r1')).toThrow();
+    svc.setReady('r1', 'b', true);
+    const room = svc.startGame('r1');
+    expect(room.started).toBe(true);
+    const tickSpy = jest.spyOn(room.world, 'tick');
+    jest.advanceTimersByTime(100);
+    expect(tickSpy).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+});

--- a/apps/server/src/game/room.service.ts
+++ b/apps/server/src/game/room.service.ts
@@ -1,1 +1,82 @@
-export class RoomService {}
+import { Injectable } from '@nestjs/common';
+import { World } from '../ecs/world';
+
+interface PlayerState {
+  ready: boolean;
+}
+
+interface RoomState {
+  id: string;
+  players: Map<string, PlayerState>;
+  started: boolean;
+  world: World;
+  interval?: NodeJS.Timeout;
+}
+
+@Injectable()
+export class RoomService {
+  private rooms = new Map<string, RoomState>();
+
+  createRoom(id: string): RoomState {
+    if (this.rooms.has(id)) {
+      throw new Error('Room already exists');
+    }
+    const room: RoomState = {
+      id,
+      players: new Map(),
+      started: false,
+      world: new World(),
+    };
+    this.rooms.set(id, room);
+    return room;
+  }
+
+  getRoom(id: string): RoomState | undefined {
+    return this.rooms.get(id);
+  }
+
+  joinRoom(roomId: string, playerId: string): RoomState {
+    const room = this.rooms.get(roomId) ?? this.createRoom(roomId);
+    room.players.set(playerId, { ready: false });
+    return room;
+  }
+
+  leaveRoom(roomId: string, playerId: string): void {
+    const room = this.rooms.get(roomId);
+    if (!room) return;
+    room.players.delete(playerId);
+    if (room.players.size === 0) {
+      if (room.interval) {
+        clearInterval(room.interval);
+      }
+      this.rooms.delete(roomId);
+    }
+  }
+
+  setReady(roomId: string, playerId: string, ready: boolean): void {
+    const room = this.rooms.get(roomId);
+    if (!room) {
+      throw new Error('Room not found');
+    }
+    const player = room.players.get(playerId);
+    if (!player) {
+      throw new Error('Player not found');
+    }
+    player.ready = ready;
+  }
+
+  startGame(roomId: string): RoomState {
+    const room = this.rooms.get(roomId);
+    if (!room) {
+      throw new Error('Room not found');
+    }
+    if (room.started) return room;
+    const allReady = [...room.players.values()].every((p) => p.ready);
+    if (!allReady) {
+      throw new Error('Not all players are ready');
+    }
+    room.started = true;
+    room.interval = setInterval(() => room.world.tick(), 100);
+    return room;
+  }
+}


### PR DESCRIPTION
## Summary
- add RoomService managing rooms, players, and readiness
- support join, leave and game start with world ticking
- test room lifecycle and start conditions

## Testing
- `pnpm --filter @snail/server test`


------
https://chatgpt.com/codex/tasks/task_e_68ba17f544cc8328b16a2f011559a88d