### PR TITLE
feat: add upkeep system with aura effects

### DIFF
--- a/apps/server/src/ecs/components.ts
+++ b/apps/server/src/ecs/components.ts
@@ -16,6 +16,11 @@ export const Base = defineComponent({
   water: Types.f32,
 });
 export const BuildTimer = defineComponent({ remaining: Types.f32 });
+export const Upkeep = defineComponent({
+  timer: Types.f32,
+  active: Types.ui8,
+  dormant_time: Types.f32,
+});
 
 export type WorldComponents = {
   position: typeof Position;
@@ -25,6 +30,7 @@ export type WorldComponents = {
   dead: typeof Dead;
   base: typeof Base;
   buildTimer: typeof BuildTimer;
+  upkeep: typeof Upkeep;
 };
 
 import params from '../config';
@@ -40,5 +46,11 @@ export function initWorker(eid: number, baseEid = 0) {
 export function initBase(eid: number) {
   Base.biomass[eid] = 0;
   Base.water[eid] = 0;
+}
+
+export function initUpkeep(eid: number, interval: number) {
+  Upkeep.timer[eid] = interval;
+  Upkeep.active[eid] = 1;
+  Upkeep.dormant_time[eid] = 0;
 }
 

--- a/apps/server/src/ecs/systems/aura.system.spec.ts
+++ b/apps/server/src/ecs/systems/aura.system.spec.ts
@@ -1,0 +1,93 @@
+import { createWorld, addEntity, addComponent } from 'bitecs';
+import { Position, Velocity, Hydration, Worker, initWorker } from '../components';
+import { movementSystem } from './movement.system';
+import { hydrationSystem } from './hydration.system';
+import { slimeDecaySystem } from './slime-decay.system';
+import type { MapDef, WaterLayer, GrassLayer, Structure, TerrainType } from '@snail/protocol';
+import baseParams from '../../config';
+const params = JSON.parse(JSON.stringify(baseParams));
+
+function makeMap(terrain: string, moisture = 0, slime = 0): MapDef {
+  return {
+    width: 1,
+    height: 1,
+    version: 1,
+    moisture,
+    tiles: [
+      {
+        terrain: terrain as unknown as TerrainType,
+        water: 'None' as WaterLayer,
+        grass: 'None' as GrassLayer,
+        structure: 'None' as Structure,
+        slime_intensity: slime,
+      },
+    ],
+  } as unknown as MapDef;
+}
+
+describe('aura effects', () => {
+  it('reduces hydration cost within aura', () => {
+    const map = makeMap('sidewalk');
+    const world = createWorld();
+    const eid = addEntity(world);
+    addComponent(world, Hydration, eid);
+    addComponent(world, Velocity, eid);
+    addComponent(world, Position, eid);
+    addComponent(world, Worker, eid);
+    initWorker(eid);
+    Hydration.value[eid] = 5;
+    Position.x[eid] = 0;
+    Position.y[eid] = 0;
+    Velocity.dx[eid] = 1;
+    Velocity.dy[eid] = 0;
+    hydrationSystem(world, map, {
+      terrain: params.terrain,
+      slime: { hydration_save_max: params.slime.hydration_save_max },
+      aura: {
+        radius: params.upkeep.aura.radius,
+        hydration_cost_hard_multiplier: params.upkeep.aura.hydration_cost_hard_multiplier,
+        bases: [{ x: 0, y: 0 }],
+      },
+    });
+    const base = params.terrain.sidewalk.hydration_cost;
+    const expected = 5 - base * params.upkeep.aura.hydration_cost_hard_multiplier;
+    expect(Hydration.value[eid]).toBeCloseTo(expected);
+  });
+
+  it('adds speed bonus within aura', () => {
+    const map = makeMap('grass');
+    const world = createWorld();
+    const eid = addEntity(world);
+    addComponent(world, Position, eid);
+    addComponent(world, Velocity, eid);
+    Position.x[eid] = 0;
+    Position.y[eid] = 0;
+    Velocity.dx[eid] = 1;
+    Velocity.dy[eid] = 0;
+    movementSystem(world, map, {
+      terrain: params.terrain,
+      slime: { speed_bonus_max: params.slime.speed_bonus_max },
+      aura: {
+        radius: params.upkeep.aura.radius,
+        speed_bonus: params.upkeep.aura.speed_bonus,
+        bases: [{ x: 0, y: 0 }],
+      },
+    });
+    expect(Position.x[eid]).toBeCloseTo(1 + params.upkeep.aura.speed_bonus);
+  });
+
+  it('slows slime decay within aura', () => {
+    const map = makeMap('sidewalk', 0, 1);
+    slimeDecaySystem(createWorld(), map, {
+      slime: { decay_per_tick: params.slime.decay_per_tick },
+      moisture: params.moisture,
+      aura: {
+        radius: params.upkeep.aura.radius,
+        slime_decay_multiplier: params.upkeep.aura.slime_decay_multiplier,
+        bases: [{ x: 0, y: 0 }],
+      },
+    });
+    const decay = params.slime.decay_per_tick.dry.sidewalk * params.upkeep.aura.slime_decay_multiplier;
+    expect(map.tiles[0].slime_intensity).toBeCloseTo(1 - decay);
+  });
+});

--- a/apps/server/src/ecs/systems/upkeep.system.spec.ts
+++ b/apps/server/src/ecs/systems/upkeep.system.spec.ts
@@ -1,0 +1,65 @@
+import { createWorld, addEntity, addComponent, hasComponent } from 'bitecs';
+import { Base, Position, Upkeep, initBase, initUpkeep } from '../components';
+import { upkeepSystem } from './upkeep.system';
+import type { MapDef, WaterLayer, GrassLayer, Structure, TerrainType } from '@snail/protocol';
+import baseParams from '../../config';
+const params = JSON.parse(JSON.stringify(baseParams));
+
+function makeMap(structure: Structure = 'Colony' as Structure): MapDef {
+  return {
+    width: 1,
+    height: 1,
+    version: 1,
+    moisture: 0,
+    tiles: [
+      {
+        terrain: 'grass' as unknown as TerrainType,
+        water: 'None' as WaterLayer,
+        grass: 'None' as GrassLayer,
+        structure,
+        slime_intensity: 0,
+      },
+    ],
+  } as unknown as MapDef;
+}
+
+describe('upkeepSystem', () => {
+  it('deducts cost and stays active when paid', () => {
+    const world = createWorld();
+    const map = makeMap('None' as Structure);
+    const eid = addEntity(world);
+    addComponent(world, Base, eid);
+    addComponent(world, Position, eid);
+    addComponent(world, Upkeep, eid);
+    initBase(eid);
+    Base.water[eid] = params.upkeep.base.water;
+    Base.biomass[eid] = params.upkeep.base.biomass;
+    Position.x[eid] = 0;
+    Position.y[eid] = 0;
+    initUpkeep(eid, 1);
+    upkeepSystem(world, map, params.upkeep);
+    expect(Base.water[eid]).toBeCloseTo(0);
+    expect(Upkeep.active[eid]).toBe(1);
+  });
+
+  it('becomes dormant and collapses after time', () => {
+    const world = createWorld();
+    const map = makeMap();
+    const eid = addEntity(world);
+    addComponent(world, Base, eid);
+    addComponent(world, Position, eid);
+    addComponent(world, Upkeep, eid);
+    initBase(eid);
+    Base.water[eid] = 0;
+    Base.biomass[eid] = 0;
+    Position.x[eid] = 0;
+    Position.y[eid] = 0;
+    initUpkeep(eid, 1);
+    upkeepSystem(world, map, params.upkeep);
+    expect(Upkeep.active[eid]).toBe(0);
+    for (let i = 0; i < params.upkeep.dormant_collapse_seconds; i++) {
+      upkeepSystem(world, map, params.upkeep);
+    }
+    expect(hasComponent(world, Base, eid)).toBe(false);
+  });
+});

--- a/apps/server/src/ecs/systems/upkeep.system.ts
+++ b/apps/server/src/ecs/systems/upkeep.system.ts
@@ -1,0 +1,56 @@
+import { IWorld, defineQuery, removeComponent } from 'bitecs';
+import { Base, Position, Upkeep } from '../components';
+import { MapDef, Structure } from '@snail/protocol';
+import { tileAt } from '../../game/terrain';
+import type { GameParams } from '../../config';
+
+interface Params {
+  interval_seconds: number;
+  base: GameParams['upkeep']['base'];
+  colony: GameParams['upkeep']['colony'];
+  dormant_collapse_seconds: number;
+}
+
+const upkeepQuery = defineQuery([Base, Upkeep, Position]);
+
+export function upkeepSystem(world: IWorld, map: MapDef, params: Params) {
+  const ents = upkeepQuery(world);
+  for (const eid of ents) {
+    Upkeep.timer[eid] -= 1;
+    if (Upkeep.timer[eid] <= 0) {
+      Upkeep.timer[eid] = params.interval_seconds;
+      const x = Math.floor(Position.x[eid]);
+      const y = Math.floor(Position.y[eid]);
+      const tile = tileAt(map, x, y);
+      const cost =
+        tile?.structure === ('Colony' as unknown as Structure)
+          ? params.colony
+          : params.base;
+      if (
+        Base.water[eid] >= cost.water &&
+        Base.biomass[eid] >= cost.biomass
+      ) {
+        Base.water[eid] -= cost.water;
+        Base.biomass[eid] -= cost.biomass;
+        Upkeep.active[eid] = 1;
+        Upkeep.dormant_time[eid] = 0;
+      } else {
+        Upkeep.active[eid] = 0;
+      }
+    }
+    if (Upkeep.active[eid] === 0) {
+      Upkeep.dormant_time[eid] += 1;
+      if (Upkeep.dormant_time[eid] >= params.dormant_collapse_seconds) {
+        removeComponent(world, Base, eid);
+        removeComponent(world, Upkeep, eid);
+        const x = Math.floor(Position.x[eid]);
+        const y = Math.floor(Position.y[eid]);
+        const tile = tileAt(map, x, y);
+        if (tile) {
+          tile.structure = 'None' as unknown as Structure;
+        }
+      }
+    }
+  }
+  return world;
+}


### PR DESCRIPTION
## Summary
- add upkeep ECS system to toggle bases between active and dormant and collapse after long dormancy
- apply base auras to movement speed, hydration cost, and slime decay
- cover upkeep transitions and aura modifiers in new specs

## Testing
- `pnpm --filter @snail/server test`


------
https://chatgpt.com/codex/tasks/task_e_68bb0db9b43c832884773dabac7a1217