### PR TITLE
feat: add colony scoring system with win/lose messaging

### DIFF
--- a/apps/server/src/ecs/systems/scoring.system.spec.ts
+++ b/apps/server/src/ecs/systems/scoring.system.spec.ts
@@ -1,0 +1,84 @@
+import {
+  createWorld,
+  addEntity,
+  addComponent,
+  removeComponent,
+} from 'bitecs';
+import { Base, Upkeep, initBase, initUpkeep } from '../components';
+import { scoringSystem, ScoreState } from './scoring.system';
+
+describe('scoringSystem', () => {
+  it('triggers victory after sustaining colonies', () => {
+    const world = createWorld();
+    const base = addEntity(world);
+    addComponent(world, Base, base);
+    addComponent(world, Upkeep, base);
+    initBase(base);
+    initUpkeep(base, 0);
+    Base.biomass[base] = 10;
+
+    const colony = addEntity(world);
+    addComponent(world, Base, colony);
+    addComponent(world, Upkeep, colony);
+    initBase(colony);
+    initUpkeep(colony, 0);
+    Base.biomass[colony] = 10;
+
+    const params = {
+      colonies_required: 2,
+      sustain_minutes: 1 / 60, // one second
+      active_min_stock_any: 5,
+      tick_rate_hz: 1,
+      starting_base: base,
+    };
+    const state: ScoreState = {
+      sustainTicks: 0,
+      colonies: new Set(),
+      activeColonies: 0,
+    };
+
+    scoringSystem(world, params, state);
+
+    expect(state.result).toBe('Victory');
+  });
+
+  it('triggers defeat when a colony collapses', () => {
+    const world = createWorld();
+    const base = addEntity(world);
+    addComponent(world, Base, base);
+    addComponent(world, Upkeep, base);
+    initBase(base);
+    initUpkeep(base, 0);
+
+    const colony = addEntity(world);
+    addComponent(world, Base, colony);
+    addComponent(world, Upkeep, colony);
+    initBase(colony);
+    initUpkeep(colony, 0);
+
+    const params = {
+      colonies_required: 1,
+      sustain_minutes: 1,
+      active_min_stock_any: 0,
+      tick_rate_hz: 1,
+      starting_base: base,
+    };
+    const state: ScoreState = {
+      sustainTicks: 0,
+      colonies: new Set(),
+      activeColonies: 0,
+    };
+
+    // initial tick to register colonies
+    scoringSystem(world, params, state);
+
+    // remove colony to simulate collapse
+    removeComponent(world, Base, colony);
+    removeComponent(world, Upkeep, colony);
+
+    scoringSystem(world, params, state);
+
+    expect(state.result).toBe('Defeat');
+  });
+});
+

--- a/apps/server/src/ecs/systems/scoring.system.ts
+++ b/apps/server/src/ecs/systems/scoring.system.ts
@@ -1,1 +1,67 @@
-export function scoringSystem() {}
+import { IWorld, defineQuery } from 'bitecs';
+import { Base, Upkeep } from '../components';
+
+interface Params {
+  colonies_required: number;
+  sustain_minutes: number;
+  active_min_stock_any: number;
+  tick_rate_hz: number;
+  /** entity id of the starting base */
+  starting_base?: number;
+}
+
+export interface ScoreState {
+  /** number of consecutive ticks meeting the sustain condition */
+  sustainTicks: number;
+  /** track known colonies to detect collapses */
+  colonies: Set<number>;
+  /** last counted active colonies */
+  activeColonies: number;
+  /** result once game is over */
+  result?: 'Victory' | 'Defeat';
+}
+
+const colonyQuery = defineQuery([Base, Upkeep]);
+
+export function scoringSystem(world: IWorld, params: Params, state: ScoreState) {
+  const eids = colonyQuery(world);
+
+  // count active colonies and ensure they have enough resources
+  let active = 0;
+  for (const eid of eids) {
+    if (
+      Upkeep.active[eid] === 1 &&
+      (Base.biomass[eid] >= params.active_min_stock_any ||
+        Base.water[eid] >= params.active_min_stock_any)
+    ) {
+      active += 1;
+    }
+  }
+
+  // sustain timer management
+  if (active >= params.colonies_required) {
+    state.sustainTicks += 1;
+  } else {
+    state.sustainTicks = 0;
+  }
+
+  // detect colony collapse
+  const newSet = new Set<number>(eids);
+  for (const id of state.colonies) {
+    if (!newSet.has(id) && id !== params.starting_base) {
+      state.result = 'Defeat';
+      break;
+    }
+  }
+  state.colonies = newSet;
+
+  // victory condition
+  const requiredTicks = params.sustain_minutes * 60 * params.tick_rate_hz;
+  if (state.sustainTicks >= requiredTicks) {
+    state.result = 'Victory';
+  }
+
+  state.activeColonies = active;
+  return state;
+}
+

--- a/apps/server/src/ws/gateway.service.ts
+++ b/apps/server/src/ws/gateway.service.ts
@@ -45,6 +45,32 @@ export class GameGateway
           client.send(payload);
         }
       });
+
+      const progress = room.world.goalProgress();
+      const progressMsg: ServerMessage = {
+        t: 'GoalProgress',
+        active: progress.active,
+        required: progress.required,
+        sustain_seconds: progress.sustain_seconds,
+        sustain_required: progress.sustain_required,
+      };
+      const progressPayload = JSON.stringify(progressMsg);
+      this.clients.forEach((client) => {
+        if (client.readyState === WebSocket.OPEN) {
+          client.send(progressPayload);
+        }
+      });
+
+      const result = room.world.goalResult();
+      if (result) {
+        const resultMsg: ServerMessage = { t: 'GoalResult', result };
+        const resultPayload = JSON.stringify(resultMsg);
+        this.clients.forEach((client) => {
+          if (client.readyState === WebSocket.OPEN) {
+            client.send(resultPayload);
+          }
+        });
+      }
     }, 100);
   }
 

--- a/libs/protocol/src/index.ts
+++ b/libs/protocol/src/index.ts
@@ -115,4 +115,12 @@ export type ServerMessage =
   | {
       t: 'State';
       entities: { id: number; x: number; y: number; hydration: number }[];
-    };
+    }
+  | {
+      t: 'GoalProgress';
+      active: number;
+      required: number;
+      sustain_seconds: number;
+      sustain_required: number;
+    }
+  | { t: 'GoalResult'; result: 'Victory' | 'Defeat' };


### PR DESCRIPTION
## Summary
- track active colony sustainment and collapse via new scoring system
- expose goal progress and victory/defeat messages through gateway
- add unit tests covering scoring success and failure

## Testing
- `pnpm --filter @snail/server test`


------
https://chatgpt.com/codex/tasks/task_e_68bb0fedb644832896eafd5a92183778