### PR TITLE
feat: add hud and overlays

### DIFF
--- a/apps/client/src/ui/entity-status.tsx
+++ b/apps/client/src/ui/entity-status.tsx
@@ -2,24 +2,40 @@ interface EntityStatusProps {
   x: number;
   y: number;
   hydration: number;
+  slimeBonus: number;
 }
 
-export function EntityStatus({ x, y, hydration }: EntityStatusProps) {
+export function EntityStatus({ x, y, hydration, slimeBonus }: EntityStatusProps) {
   const hydrationPct = Math.max(0, Math.min(100, hydration));
+  const slimePct = Math.max(0, Math.min(100, slimeBonus));
   return (
     <div className="p-4 border rounded bg-white max-w-sm">
       <div className="mb-2">
         <span className="font-semibold">Position:</span> ({x.toFixed(2)}, {y.toFixed(2)})
       </div>
-      <div>
+      <div className="mb-2" title="Current hydration level">
         <div className="flex justify-between mb-1 text-sm">
           <span className="font-semibold">Hydration</span>
-          <span>{hydrationPct.toFixed(0)}%</span>
+          <span>
+            {hydrationPct.toFixed(0)}/100
+          </span>
         </div>
         <div className="w-full bg-gray-200 rounded h-2">
           <div
             className="bg-blue-500 h-2 rounded"
             style={{ width: `${hydrationPct}%` }}
+          ></div>
+        </div>
+      </div>
+      <div title="Speed bonus provided by slime trail">
+        <div className="flex justify-between mb-1 text-sm">
+          <span className="font-semibold">Slime Bonus</span>
+          <span>{slimePct.toFixed(0)}%</span>
+        </div>
+        <div className="w-full bg-gray-200 rounded h-2">
+          <div
+            className="bg-green-500 h-2 rounded"
+            style={{ width: `${slimePct}%` }}
           ></div>
         </div>
       </div>

--- a/apps/client/src/ui/hud.tsx
+++ b/apps/client/src/ui/hud.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+interface HUDProps {
+  inventory?: { water?: number; biomass?: number } | null;
+  goal?: {
+    active: number;
+    required: number;
+    sustain_seconds: number;
+    sustain_required: number;
+  } | null;
+}
+
+export function HUD({ inventory, goal }: HUDProps) {
+  if (!inventory && !goal) return null;
+  const remaining = goal
+    ? Math.max(0, goal.sustain_required - goal.sustain_seconds)
+    : 0;
+  return (
+    <div className="fixed top-2 left-1/2 -translate-x-1/2 bg-white bg-opacity-80 border rounded p-2 text-sm space-y-1">
+      {inventory && (
+        <div>
+          <span className="font-semibold mr-1">Base:</span>
+          <span className="mr-2">Water {inventory.water ?? 0}</span>
+          <span>Biomass {inventory.biomass ?? 0}</span>
+        </div>
+      )}
+      {goal && (
+        <div>
+          <span className="mr-2">Colonies {goal.active}/{goal.required}</span>
+          <span>Goal in {remaining.toFixed(1)}s</span>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/apps/client/src/ui/log-console.tsx
+++ b/apps/client/src/ui/log-console.tsx
@@ -7,6 +7,8 @@ interface LogConsoleProps {
   inLogs: LogEntry[];
   outLogs: LogEntry[];
   systemLogs: LogEntry[];
+  upkeepLogs: LogEntry[];
+  goalLogs: LogEntry[];
 }
 
 function LogColumn({ title, logs }: { title: string; logs: LogEntry[] }) {
@@ -34,12 +36,20 @@ function LogColumn({ title, logs }: { title: string; logs: LogEntry[] }) {
   );
 }
 
-export function LogConsole({ inLogs, outLogs, systemLogs }: LogConsoleProps) {
+export function LogConsole({
+  inLogs,
+  outLogs,
+  systemLogs,
+  upkeepLogs,
+  goalLogs,
+}: LogConsoleProps) {
   return (
-    <div className="grid grid-cols-3 gap-4 mt-4">
+    <div className="grid grid-cols-5 gap-4 mt-4">
       <LogColumn title="IN" logs={inLogs} />
       <LogColumn title="OUT" logs={outLogs} />
       <LogColumn title="System" logs={systemLogs} />
+      <LogColumn title="Upkeep" logs={upkeepLogs} />
+      <LogColumn title="Goal" logs={goalLogs} />
     </div>
   );
 }

--- a/apps/client/src/ui/map-3d-view.tsx
+++ b/apps/client/src/ui/map-3d-view.tsx
@@ -40,6 +40,11 @@ const structureColors: Record<Structure, number> = {
   [Structure.Bridge]: 0x8b4513,
 };
 
+const resourceColors = {
+  biomass: 0x00ff00,
+  water: 0x1e90ff,
+};
+
 interface Map3DViewProps {
   map: MapDef;
 }
@@ -84,6 +89,9 @@ export function Map3DView({ map }: Map3DViewProps) {
     scene.add(grid);
 
     const waterMeshes: THREE.Mesh[] = [];
+    const slimeMeshes: THREE.Mesh[] = [];
+    const resourceGroup = new THREE.Group();
+    scene.add(resourceGroup);
 
     const terrainGeom = new THREE.BoxGeometry(1, 0.1, 1);
     const waterThin = new THREE.BoxGeometry(1, 0.05, 1);
@@ -156,6 +164,28 @@ export function Map3DView({ map }: Map3DViewProps) {
           slime.rotation.x = -Math.PI / 2;
           slime.position.set(x, 0.06, y);
           scene.add(slime);
+          slimeMeshes.push(slime);
+        }
+
+        if (tile.resources) {
+          if (tile.resources.biomass) {
+            const mat = new THREE.MeshBasicMaterial({
+              color: resourceColors.biomass,
+            });
+            const geom = new THREE.SphereGeometry(0.1, 8, 8);
+            const marker = new THREE.Mesh(geom, mat);
+            marker.position.set(x + 0.25, 0.1, y + 0.25);
+            resourceGroup.add(marker);
+          }
+          if (tile.resources.water) {
+            const mat = new THREE.MeshBasicMaterial({
+              color: resourceColors.water,
+            });
+            const geom = new THREE.SphereGeometry(0.1, 8, 8);
+            const marker = new THREE.Mesh(geom, mat);
+            marker.position.set(x + 0.75, 0.1, y + 0.25);
+            resourceGroup.add(marker);
+          }
         }
       }
     }
@@ -185,6 +215,8 @@ export function Map3DView({ map }: Map3DViewProps) {
     };
     window.addEventListener('resize', onResize);
 
+    let showSlime = true;
+
     const keyHandler = (e: KeyboardEvent) => {
       switch (e.key) {
         case 'g':
@@ -194,6 +226,11 @@ export function Map3DView({ map }: Map3DViewProps) {
         case 'w':
         case 'W':
           animateWater = !animateWater;
+          break;
+        case 's':
+        case 'S':
+          showSlime = !showSlime;
+          slimeMeshes.forEach((m) => (m.visible = showSlime));
           break;
         case ' ':
           paused = !paused;


### PR DESCRIPTION
## Summary
- show base inventory, active colonies, and goal timer in new HUD
- add hydration/slime tooltips on entity status
- render resources and toggleable slime heatmap in 3D map
- log upkeep and goal progress in console

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb137892548328ba8ee0df19de2ba2