### PR TITLE
feat: configurable world tick

### DIFF
--- a/apps/server/src/ecs/systems/update-moisture-and-auras.system.ts
+++ b/apps/server/src/ecs/systems/update-moisture-and-auras.system.ts
@@ -1,0 +1,54 @@
+import { IWorld, defineQuery } from 'bitecs';
+import { MapDef } from '@snail/protocol';
+import { Position, Upkeep } from '../components';
+import type { GameParams } from '../../config';
+
+interface SidewalkDefaults {
+  base_speed: number;
+  hydration_cost: number;
+}
+
+interface AuraParams {
+  bases: { x: number; y: number }[];
+  radius: number;
+  speed_bonus: number;
+  hydration_cost_hard_multiplier: number;
+  slime_decay_multiplier: number;
+}
+
+const baseQuery = defineQuery([Position, Upkeep]);
+
+export function updateMoistureAndAurasSystem(
+  world: IWorld,
+  map: MapDef,
+  params: GameParams,
+  sidewalkDefaults: SidewalkDefaults,
+): AuraParams {
+  map.moisture = Math.max(0, map.moisture - 1);
+
+  if (map.moisture < params.moisture.thresholds.damp) {
+    params.terrain.sidewalk.base_speed = params.moisture.sidewalk_dry_speed;
+    params.terrain.sidewalk.hydration_cost =
+      params.moisture.sidewalk_dry_hydration_cost;
+  } else {
+    params.terrain.sidewalk.base_speed = sidewalkDefaults.base_speed;
+    params.terrain.sidewalk.hydration_cost = sidewalkDefaults.hydration_cost;
+  }
+
+  const bases: { x: number; y: number }[] = [];
+  const ents = baseQuery(world);
+  for (const eid of ents) {
+    if (Upkeep.active[eid]) {
+      bases.push({ x: Position.x[eid], y: Position.y[eid] });
+    }
+  }
+
+  return {
+    bases,
+    radius: params.upkeep.aura.radius,
+    speed_bonus: params.upkeep.aura.speed_bonus,
+    hydration_cost_hard_multiplier:
+      params.upkeep.aura.hydration_cost_hard_multiplier,
+    slime_decay_multiplier: params.upkeep.aura.slime_decay_multiplier,
+  };
+}

--- a/apps/server/src/ecs/world-order.spec.ts
+++ b/apps/server/src/ecs/world-order.spec.ts
@@ -2,11 +2,15 @@ import { World } from './world';
 import baseParams from '../config';
 import type { MapDef, GameParams, TerrainType } from '@snail/protocol';
 
-type TestWorld = World & { map: MapDef; params: GameParams };
+interface TestWorld {
+  map: MapDef;
+  params: GameParams;
+  tick: () => void;
+}
 
 describe('world system order', () => {
   it('runs systems in configured order', () => {
-    const worldA = new World() as TestWorld;
+    const worldA = new World() as unknown as TestWorld;
     worldA.map.moisture = baseParams.moisture.thresholds.wet;
     worldA.map.tiles[0].terrain = 'sidewalk' as unknown as TerrainType;
     worldA.map.tiles[0].slime_intensity = 1;
@@ -15,7 +19,7 @@ describe('world system order', () => {
     const dampDecay = baseParams.slime.decay_per_tick.damp.sidewalk;
     expect(worldA.map.tiles[0].slime_intensity).toBeCloseTo(1 - dampDecay);
 
-    const worldB = new World() as TestWorld;
+    const worldB = new World() as unknown as TestWorld;
     worldB.map.moisture = baseParams.moisture.thresholds.wet;
     worldB.map.tiles[0].terrain = 'sidewalk' as unknown as TerrainType;
     worldB.map.tiles[0].slime_intensity = 1;

--- a/apps/server/src/ecs/world-order.spec.ts
+++ b/apps/server/src/ecs/world-order.spec.ts
@@ -1,0 +1,32 @@
+import { World } from './world';
+import baseParams from '../config';
+
+describe('world system order', () => {
+  it('runs systems in configured order', () => {
+    const worldA = new World();
+    const mapA = (worldA as any).map;
+    mapA.moisture = baseParams.moisture.thresholds.wet;
+    mapA.tiles[0].terrain = 'sidewalk' as any;
+    mapA.tiles[0].slime_intensity = 1;
+    (worldA as any).params.simulation.order = [
+      'update_moisture_and_auras',
+      'slime_decay',
+    ];
+    worldA.tick();
+    const dampDecay = baseParams.slime.decay_per_tick.damp.sidewalk;
+    expect(mapA.tiles[0].slime_intensity).toBeCloseTo(1 - dampDecay);
+
+    const worldB = new World();
+    const mapB = (worldB as any).map;
+    mapB.moisture = baseParams.moisture.thresholds.wet;
+    mapB.tiles[0].terrain = 'sidewalk' as any;
+    mapB.tiles[0].slime_intensity = 1;
+    (worldB as any).params.simulation.order = [
+      'slime_decay',
+      'update_moisture_and_auras',
+    ];
+    worldB.tick();
+    const wetDecay = baseParams.slime.decay_per_tick.wet.sidewalk;
+    expect(mapB.tiles[0].slime_intensity).toBeCloseTo(1 - wetDecay);
+  });
+});

--- a/apps/server/src/ecs/world-order.spec.ts
+++ b/apps/server/src/ecs/world-order.spec.ts
@@ -1,32 +1,27 @@
 import { World } from './world';
 import baseParams from '../config';
+import type { MapDef, GameParams, TerrainType } from '@snail/protocol';
+
+type TestWorld = World & { map: MapDef; params: GameParams };
 
 describe('world system order', () => {
   it('runs systems in configured order', () => {
-    const worldA = new World();
-    const mapA = (worldA as any).map;
-    mapA.moisture = baseParams.moisture.thresholds.wet;
-    mapA.tiles[0].terrain = 'sidewalk' as any;
-    mapA.tiles[0].slime_intensity = 1;
-    (worldA as any).params.simulation.order = [
-      'update_moisture_and_auras',
-      'slime_decay',
-    ];
+    const worldA = new World() as TestWorld;
+    worldA.map.moisture = baseParams.moisture.thresholds.wet;
+    worldA.map.tiles[0].terrain = 'sidewalk' as unknown as TerrainType;
+    worldA.map.tiles[0].slime_intensity = 1;
+    worldA.params.simulation.order = ['update_moisture_and_auras', 'slime_decay'];
     worldA.tick();
     const dampDecay = baseParams.slime.decay_per_tick.damp.sidewalk;
-    expect(mapA.tiles[0].slime_intensity).toBeCloseTo(1 - dampDecay);
+    expect(worldA.map.tiles[0].slime_intensity).toBeCloseTo(1 - dampDecay);
 
-    const worldB = new World();
-    const mapB = (worldB as any).map;
-    mapB.moisture = baseParams.moisture.thresholds.wet;
-    mapB.tiles[0].terrain = 'sidewalk' as any;
-    mapB.tiles[0].slime_intensity = 1;
-    (worldB as any).params.simulation.order = [
-      'slime_decay',
-      'update_moisture_and_auras',
-    ];
+    const worldB = new World() as TestWorld;
+    worldB.map.moisture = baseParams.moisture.thresholds.wet;
+    worldB.map.tiles[0].terrain = 'sidewalk' as unknown as TerrainType;
+    worldB.map.tiles[0].slime_intensity = 1;
+    worldB.params.simulation.order = ['slime_decay', 'update_moisture_and_auras'];
     worldB.tick();
     const wetDecay = baseParams.slime.decay_per_tick.wet.sidewalk;
-    expect(mapB.tiles[0].slime_intensity).toBeCloseTo(1 - wetDecay);
+    expect(worldB.map.tiles[0].slime_intensity).toBeCloseTo(1 - wetDecay);
   });
 });

--- a/apps/server/src/ecs/world.ts
+++ b/apps/server/src/ecs/world.ts
@@ -10,6 +10,9 @@ import { movementSystem } from './systems/movement.system';
 import { hydrationSystem } from './systems/hydration.system';
 import { slimeDepositSystem } from './systems/slime-deposit.system';
 import { slimeDecaySystem } from './systems/slime-decay.system';
+import { harvestSystem } from './systems/harvest.system';
+import { upkeepSystem } from './systems/upkeep.system';
+import { updateMoistureAndAurasSystem } from './systems/update-moisture-and-auras.system';
 import { scoringSystem, ScoreState } from './systems/scoring.system';
 import { MapService } from '../game/map.service';
 import { MapDef, GameParams } from '@snail/protocol';
@@ -21,6 +24,15 @@ export class World {
   private map: MapDef;
   private params: GameParams;
   private score: ScoreState;
+  private aura?: {
+    radius: number;
+    speed_bonus: number;
+    hydration_cost_hard_multiplier: number;
+    slime_decay_multiplier: number;
+    bases: { x: number; y: number }[];
+  };
+  private sidewalkDefaults: { base_speed: number; hydration_cost: number };
+  private dispatch: Record<string, () => void>;
 
   constructor() {
     this.world = createWorld();
@@ -39,30 +51,75 @@ export class World {
     this.map = svc.load('test');
     this.params = params as GameParams;
     this.score = { sustainTicks: 0, colonies: new Set(), activeColonies: 0 };
+    this.aura = undefined;
+    this.sidewalkDefaults = {
+      base_speed: this.params.terrain.sidewalk.base_speed,
+      hydration_cost: this.params.terrain.sidewalk.hydration_cost,
+    };
+    this.dispatch = {
+      update_moisture_and_auras: () => {
+        this.aura = updateMoistureAndAurasSystem(
+          this.world,
+          this.map,
+          this.params,
+          this.sidewalkDefaults,
+        );
+      },
+      slime_decay: () => {
+        slimeDecaySystem(this.world, this.map, {
+          slime: { decay_per_tick: this.params.slime.decay_per_tick },
+          moisture: this.params.moisture,
+          aura: this.aura,
+        });
+      },
+      unit_movement_and_slime_deposit: () => {
+        movementSystem(this.world, this.map, {
+          terrain: this.params.terrain,
+          slime: { speed_bonus_max: this.params.slime.speed_bonus_max },
+          aura: this.aura,
+        });
+        hydrationSystem(this.world, this.map, {
+          terrain: this.params.terrain,
+          slime: { hydration_save_max: this.params.slime.hydration_save_max },
+          aura: this.aura,
+        });
+        slimeDepositSystem(this.world, this.map, {
+          deposit_rate_per_step: this.params.slime.deposit_rate_per_step,
+          terrain: this.params.terrain,
+        });
+      },
+      gather_and_deliver: () => {
+        harvestSystem(this.world, this.map);
+      },
+      upkeep_tick_if_due: () => {
+        upkeepSystem(this.world, this.map, {
+          interval_seconds: this.params.upkeep.interval_seconds,
+          base: this.params.upkeep.base,
+          colony: this.params.upkeep.colony,
+          dormant_collapse_seconds: this.params.upkeep.dormant_collapse_seconds,
+        });
+      },
+      check_goal: () => {
+        scoringSystem(
+          this.world,
+          {
+            colonies_required: this.params.goal.colonies_required,
+            sustain_minutes: this.params.goal.sustain_minutes,
+            active_min_stock_any: this.params.goal.active_min_stock_any,
+            tick_rate_hz: this.params.simulation.tick_rate_hz,
+            starting_base: undefined,
+          },
+          this.score,
+        );
+      },
+    };
   }
 
   tick() {
-    slimeDecaySystem(this.world, this.map, {
-      slime: { decay_per_tick: this.params.slime.decay_per_tick },
-      moisture: this.params.moisture,
-    });
-    movementSystem(this.world, this.map, this.params);
-    hydrationSystem(this.world, this.map, this.params);
-    slimeDepositSystem(this.world, this.map, {
-      deposit_rate_per_step: this.params.slime.deposit_rate_per_step,
-      terrain: this.params.terrain,
-    });
-    scoringSystem(
-      this.world,
-      {
-        colonies_required: this.params.goal.colonies_required,
-        sustain_minutes: this.params.goal.sustain_minutes,
-        active_min_stock_any: this.params.goal.active_min_stock_any,
-        tick_rate_hz: this.params.simulation.tick_rate_hz,
-        starting_base: undefined,
-      },
-      this.score,
-    );
+    for (const step of this.params.simulation.order) {
+      const fn = this.dispatch[step];
+      if (fn) fn();
+    }
   }
 
   snapshot() {


### PR DESCRIPTION
## Summary
- allow configurable simulation order via dispatch table
- add system to update moisture and aura effects
- cover dynamic order with integration test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb3e37b96083288091128791dc6b40