### PR TITLE
feat(ai): add slime-aware pathfinding and behaviors

### DIFF
--- a/apps/server/src/ai/convoy.ts
+++ b/apps/server/src/ai/convoy.ts
@@ -1,0 +1,11 @@
+import { MapDef } from '@snail/protocol';
+import { findPath, PathParams, Point } from './pathfinding';
+
+export function convoyPath(
+  map: MapDef,
+  start: Point,
+  goal: Point,
+  params: PathParams,
+): Point[] {
+  return findPath(map, start, goal, { ...params, slimePreference: 0.5 });
+}

--- a/apps/server/src/ai/maintenance.ts
+++ b/apps/server/src/ai/maintenance.ts
@@ -1,0 +1,30 @@
+import { MapDef } from '@snail/protocol';
+import { tileAt } from '../game/terrain';
+
+export interface WorkerPos { id: number; x: number; y: number }
+export interface Task { worker: number; target: { x: number; y: number } }
+
+export function scheduleMaintenance(
+  map: MapDef,
+  critical: { x: number; y: number }[],
+  workers: WorkerPos[],
+): Task[] {
+  const tasks: Task[] = [];
+  for (const t of critical) {
+    const tile = tileAt(map, t.x, t.y);
+    if (!tile || tile.slime_intensity >= 0.2) continue;
+    let best: WorkerPos | undefined;
+    let bestDist = Infinity;
+    for (const w of workers) {
+      const dist = Math.abs(w.x - t.x) + Math.abs(w.y - t.y);
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = w;
+      }
+    }
+    if (best) {
+      tasks.push({ worker: best.id, target: { x: t.x, y: t.y } });
+    }
+  }
+  return tasks;
+}

--- a/apps/server/src/ai/pathfinding.spec.ts
+++ b/apps/server/src/ai/pathfinding.spec.ts
@@ -1,4 +1,10 @@
-import { MapDef } from '@snail/protocol';
+import type {
+  MapDef,
+  TerrainType,
+  WaterLayer,
+  GrassLayer,
+  Structure,
+} from '@snail/protocol';
 import { tileAt } from '../game/terrain';
 import { findPath, PathParams } from './pathfinding';
 import { pioneer } from './pioneer';
@@ -11,18 +17,56 @@ const terrainParams = {
 const params: PathParams = { terrain: terrainParams, k: 2 };
 
 function mapWithSlime(bottom: number): MapDef {
+  const sidewalk = 'sidewalk' as unknown as TerrainType;
+
   return {
     width: 3,
     height: 2,
     version: 1,
     moisture: 0,
     tiles: [
-      { terrain: 'sidewalk' as any, water: 'None' as any, grass: 'None' as any, structure: 'None' as any, slime_intensity: 0 },
-      { terrain: 'sidewalk' as any, water: 'None' as any, grass: 'None' as any, structure: 'None' as any, slime_intensity: 0 },
-      { terrain: 'sidewalk' as any, water: 'None' as any, grass: 'None' as any, structure: 'None' as any, slime_intensity: 0 },
-      { terrain: 'sidewalk' as any, water: 'None' as any, grass: 'None' as any, structure: 'None' as any, slime_intensity: bottom },
-      { terrain: 'sidewalk' as any, water: 'None' as any, grass: 'None' as any, structure: 'None' as any, slime_intensity: bottom },
-      { terrain: 'sidewalk' as any, water: 'None' as any, grass: 'None' as any, structure: 'None' as any, slime_intensity: bottom },
+      {
+        terrain: sidewalk,
+        water: 'None' as WaterLayer,
+        grass: 'None' as GrassLayer,
+        structure: 'None' as Structure,
+        slime_intensity: 0,
+      },
+      {
+        terrain: sidewalk,
+        water: 'None' as WaterLayer,
+        grass: 'None' as GrassLayer,
+        structure: 'None' as Structure,
+        slime_intensity: 0,
+      },
+      {
+        terrain: sidewalk,
+        water: 'None' as WaterLayer,
+        grass: 'None' as GrassLayer,
+        structure: 'None' as Structure,
+        slime_intensity: 0,
+      },
+      {
+        terrain: sidewalk,
+        water: 'None' as WaterLayer,
+        grass: 'None' as GrassLayer,
+        structure: 'None' as Structure,
+        slime_intensity: bottom,
+      },
+      {
+        terrain: sidewalk,
+        water: 'None' as WaterLayer,
+        grass: 'None' as GrassLayer,
+        structure: 'None' as Structure,
+        slime_intensity: bottom,
+      },
+      {
+        terrain: sidewalk,
+        water: 'None' as WaterLayer,
+        grass: 'None' as GrassLayer,
+        structure: 'None' as Structure,
+        slime_intensity: bottom,
+      },
     ],
   };
 }

--- a/apps/server/src/ai/pathfinding.spec.ts
+++ b/apps/server/src/ai/pathfinding.spec.ts
@@ -1,0 +1,76 @@
+import { MapDef } from '@snail/protocol';
+import { tileAt } from '../game/terrain';
+import { findPath, PathParams } from './pathfinding';
+import { pioneer } from './pioneer';
+import { convoyPath } from './convoy';
+import { scheduleMaintenance } from './maintenance';
+
+const terrainParams = {
+  sidewalk: { base_speed: 1, hydration_cost: 1, slime_weight: 1 },
+};
+const params: PathParams = { terrain: terrainParams, k: 2 };
+
+function mapWithSlime(bottom: number): MapDef {
+  return {
+    width: 3,
+    height: 2,
+    version: 1,
+    moisture: 0,
+    tiles: [
+      { terrain: 'sidewalk' as any, water: 'None' as any, grass: 'None' as any, structure: 'None' as any, slime_intensity: 0 },
+      { terrain: 'sidewalk' as any, water: 'None' as any, grass: 'None' as any, structure: 'None' as any, slime_intensity: 0 },
+      { terrain: 'sidewalk' as any, water: 'None' as any, grass: 'None' as any, structure: 'None' as any, slime_intensity: 0 },
+      { terrain: 'sidewalk' as any, water: 'None' as any, grass: 'None' as any, structure: 'None' as any, slime_intensity: bottom },
+      { terrain: 'sidewalk' as any, water: 'None' as any, grass: 'None' as any, structure: 'None' as any, slime_intensity: bottom },
+      { terrain: 'sidewalk' as any, water: 'None' as any, grass: 'None' as any, structure: 'None' as any, slime_intensity: bottom },
+    ],
+  };
+}
+
+describe('ai pathfinding', () => {
+  it('prefers slime path on hard terrain', () => {
+    const map = mapWithSlime(1);
+    const path = findPath(map, { x: 0, y: 0 }, { x: 2, y: 0 }, params);
+    expect(path).toEqual([
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+      { x: 2, y: 1 },
+      { x: 2, y: 0 },
+    ]);
+  });
+
+  it('pioneer paints path when none exists', () => {
+    const map = mapWithSlime(0);
+    const trip = pioneer(map, { x: 0, y: 0 }, { x: 2, y: 0 }, params);
+    expect(trip.length).toBeGreaterThan(0);
+    expect(tileAt(map, 1, 0)?.slime_intensity ?? 0).toBeGreaterThan(0);
+  });
+
+  it('convoy prefers tiles with slime > 0.3', () => {
+    const map = mapWithSlime(0.5);
+    const path = convoyPath(map, { x: 0, y: 0 }, { x: 2, y: 0 }, params);
+    expect(path).toEqual([
+      { x: 0, y: 0 },
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+      { x: 2, y: 1 },
+      { x: 2, y: 0 },
+    ]);
+  });
+
+  it('schedules maintenance when slime drops below threshold', () => {
+    const map = mapWithSlime(0);
+    map.tiles[1].slime_intensity = 0.1; // critical tile (1,0)
+    const tasks = scheduleMaintenance(map, [{ x: 1, y: 0 }], [
+      { id: 1, x: 0, y: 0 },
+      { id: 2, x: 2, y: 2 },
+    ]);
+    expect(tasks).toEqual([{ worker: 1, target: { x: 1, y: 0 } }]);
+    map.tiles[1].slime_intensity = 0.5;
+    const none = scheduleMaintenance(map, [{ x: 1, y: 0 }], [
+      { id: 1, x: 0, y: 0 },
+    ]);
+    expect(none).toHaveLength(0);
+  });
+});

--- a/apps/server/src/ai/pathfinding.ts
+++ b/apps/server/src/ai/pathfinding.ts
@@ -1,0 +1,88 @@
+import { MapDef, GameParams } from '@snail/protocol';
+import { terrainAt, tileAt } from '../game/terrain';
+
+export interface Point { x: number; y: number }
+
+export interface PathParams {
+  terrain: GameParams['terrain'];
+  k: number; // slime cost reduction factor
+  slimePreference?: number; // additional cost reduction when slime_intensity > 0.3
+}
+
+function heuristic(a: Point, b: Point) {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}
+
+function stepCost(map: MapDef, x: number, y: number, params: PathParams) {
+  const terrain = terrainAt(map, x, y);
+  const tile = tileAt(map, x, y);
+  const t = params.terrain?.[terrain ?? ''];
+  const base = 1 + (t?.hydration_cost ?? 0);
+  let cost = base;
+  if ((t?.hydration_cost ?? 0) > 0) {
+    cost = Math.max(0, base - params.k * (tile?.slime_intensity ?? 0));
+  }
+  if (params.slimePreference && (tile?.slime_intensity ?? 0) > 0.3) {
+    cost -= params.slimePreference;
+  }
+  return Math.max(0, cost);
+}
+
+export function findPath(
+  map: MapDef,
+  start: Point,
+  goal: Point,
+  params: PathParams,
+): Point[] {
+  const key = (x: number, y: number) => `${x},${y}`;
+  interface Node { x: number; y: number; g: number; f: number }
+  const open: Node[] = [{ x: start.x, y: start.y, g: 0, f: heuristic(start, goal) }];
+  const came = new Map<string, Point>();
+  const gScore = new Map<string, number>([[key(start.x, start.y), 0]]);
+  const closed = new Set<string>();
+
+  while (open.length) {
+    open.sort((a, b) => a.f - b.f);
+    const current = open.shift()!;
+    const ck = key(current.x, current.y);
+    if (current.x === goal.x && current.y === goal.y) {
+      const path: Point[] = [{ x: current.x, y: current.y }];
+      let k = ck;
+      while (came.has(k)) {
+        const p = came.get(k)!;
+        path.push({ x: p.x, y: p.y });
+        k = key(p.x, p.y);
+      }
+      return path.reverse();
+    }
+    closed.add(ck);
+    const neighbors = [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1],
+    ];
+    for (const [dx, dy] of neighbors) {
+      const nx = current.x + dx;
+      const ny = current.y + dy;
+      if (!tileAt(map, nx, ny)) continue;
+      const nk = key(nx, ny);
+      if (closed.has(nk)) continue;
+      const step = stepCost(map, nx, ny, params);
+      const tentative = current.g + step;
+      if (tentative < (gScore.get(nk) ?? Infinity)) {
+        came.set(nk, { x: current.x, y: current.y });
+        gScore.set(nk, tentative);
+        const f = tentative + heuristic({ x: nx, y: ny }, goal);
+        const node = open.find((n) => n.x === nx && n.y === ny);
+        if (node) {
+          node.g = tentative;
+          node.f = f;
+        } else {
+          open.push({ x: nx, y: ny, g: tentative, f });
+        }
+      }
+    }
+  }
+  return [];
+}

--- a/apps/server/src/ai/pioneer.ts
+++ b/apps/server/src/ai/pioneer.ts
@@ -1,0 +1,29 @@
+import { MapDef } from '@snail/protocol';
+import { tileAt } from '../game/terrain';
+import { findPath, PathParams, Point } from './pathfinding';
+
+/**
+ * Pioneer behavior: if no slime path exists between start and goal,
+ * return a round-trip path that paints slime along the way.
+ */
+export function pioneer(
+  map: MapDef,
+  start: Point,
+  goal: Point,
+  params: PathParams,
+): Point[] {
+  const path = findPath(map, start, goal, params);
+  const hasSlime = path.some((p) => (tileAt(map, p.x, p.y)?.slime_intensity ?? 0) > 0);
+  if (hasSlime || path.length === 0) {
+    return [];
+  }
+  const pioneerPath = findPath(map, start, goal, { ...params, k: 0 });
+  for (const p of pioneerPath) {
+    const tile = tileAt(map, p.x, p.y);
+    if (tile) {
+      tile.slime_intensity = Math.max(tile.slime_intensity, 1);
+    }
+  }
+  const back = [...pioneerPath].reverse().slice(1);
+  return pioneerPath.concat(back);
+}


### PR DESCRIPTION
## Summary
- add A* pathfinding with slime-aware cost
- pioneer paints slime path when trail absent
- convoy units prefer slime tiles and maintenance tasks refresh critical paths

## Testing
- `pnpm --filter @snail/server test`

------
https://chatgpt.com/codex/tasks/task_e_68bb93d212dc832890f4cb770f42d9b4