### PR TITLE
feat(client): redesign HUD and logs UI

### DIFF
--- a/apps/client/src/ui/components.tsx
+++ b/apps/client/src/ui/components.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export const Card: React.FC<React.PropsWithChildren<{ className?: string }>> = ({
+  children,
+  className = '',
+}) => (
+  <div className={`bg-white/80 backdrop-blur border rounded shadow-sm ${className}`}>
+    {children}
+  </div>
+);
+
+interface ProgressBarProps {
+  value: number; // 0..1
+  color?: string;
+}
+
+export function ProgressBar({ value, color = 'bg-green-500' }: ProgressBarProps) {
+  const pct = Math.max(0, Math.min(100, value * 100));
+  return (
+    <div className="w-full bg-gray-200 rounded h-2 overflow-hidden">
+      <div className={`${color} h-2 transition-all duration-300`} style={{ width: `${pct}%` }} />
+    </div>
+  );
+}
+

--- a/apps/client/src/ui/hud.tsx
+++ b/apps/client/src/ui/hud.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Card, ProgressBar } from './components';
 
 interface HUDProps {
   inventory?: { water?: number; biomass?: number } | null;
@@ -12,25 +13,38 @@ interface HUDProps {
 
 export function HUD({ inventory, goal }: HUDProps) {
   if (!inventory && !goal) return null;
-  const remaining = goal
-    ? Math.max(0, goal.sustain_required - goal.sustain_seconds)
-    : 0;
+  const remaining = React.useMemo(
+    () => (goal ? Math.max(0, goal.sustain_required - goal.sustain_seconds) : 0),
+    [goal]
+  );
+  const goalProgress = goal ? goal.sustain_seconds / goal.sustain_required : 0;
+
   return (
-    <div className="fixed top-2 left-1/2 -translate-x-1/2 bg-white bg-opacity-80 border rounded p-2 text-sm space-y-1">
+    <Card className="fixed top-2 left-1/2 -translate-x-1/2 px-4 py-2 text-sm space-y-2 min-w-[240px]">
       {inventory && (
-        <div>
-          <span className="font-semibold mr-1">Base:</span>
-          <span className="mr-2">Water {inventory.water ?? 0}</span>
-          <span>Biomass {inventory.biomass ?? 0}</span>
+        <div className="flex items-center justify-around text-center">
+          <div className="flex items-center space-x-1">
+            <span className="font-semibold">💧</span>
+            <span>{inventory.water ?? 0}</span>
+          </div>
+          <div className="flex items-center space-x-1">
+            <span className="font-semibold">🌿</span>
+            <span>{inventory.biomass ?? 0}</span>
+          </div>
         </div>
       )}
       {goal && (
-        <div>
-          <span className="mr-2">Colonies {goal.active}/{goal.required}</span>
-          <span>Goal in {remaining.toFixed(1)}s</span>
+        <div className="space-y-1">
+          <div className="flex justify-between text-xs">
+            <span>
+              Colonies {goal.active}/{goal.required}
+            </span>
+            <span>{remaining.toFixed(1)}s</span>
+          </div>
+          <ProgressBar value={goalProgress} color="bg-indigo-500" />
         </div>
       )}
-    </div>
+    </Card>
   );
 }
 

--- a/apps/client/src/ui/log-console.tsx
+++ b/apps/client/src/ui/log-console.tsx
@@ -1,5 +1,6 @@
 
-import { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
+import { Card } from './components';
 
 export type LogEntry = { ts: number; msg: string };
 
@@ -11,7 +12,13 @@ interface LogConsoleProps {
   goalLogs: LogEntry[];
 }
 
-function LogColumn({ title, logs }: { title: string; logs: LogEntry[] }) {
+const LogColumn = React.memo(function LogColumn({
+  title,
+  logs,
+}: {
+  title: string;
+  logs: LogEntry[];
+}) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -20,21 +27,23 @@ function LogColumn({ title, logs }: { title: string; logs: LogEntry[] }) {
   }, [logs]);
 
   return (
-    <div className="bg-white border rounded p-2 h-48 overflow-auto" ref={ref}>
-      <h3 className="font-semibold mb-1 text-sm">{title}</h3>
-      <ul className="text-xs space-y-1">
-        {logs.map((log, i) => (
-          <li key={i}>
-            <span className="text-gray-500 mr-1">
-              {new Date(log.ts).toLocaleTimeString()}
-            </span>
-            {log.msg}
-          </li>
-        ))}
-      </ul>
-    </div>
+    <Card className="h-48 flex flex-col">
+      <h3 className="font-semibold mb-1 text-sm px-2 pt-2">{title}</h3>
+      <div ref={ref} className="flex-1 overflow-auto px-2 pb-2">
+        <ul className="text-xs space-y-1">
+          {logs.map((log, i) => (
+            <li key={i}>
+              <span className="text-gray-500 mr-1">
+                {new Date(log.ts).toLocaleTimeString()}
+              </span>
+              {log.msg}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Card>
   );
-}
+});
 
 export function LogConsole({
   inLogs,
@@ -44,7 +53,7 @@ export function LogConsole({
   goalLogs,
 }: LogConsoleProps) {
   return (
-    <div className="grid grid-cols-5 gap-4 mt-4">
+    <div className="grid grid-cols-1 sm:grid-cols-5 gap-4 mt-4">
       <LogColumn title="IN" logs={inLogs} />
       <LogColumn title="OUT" logs={outLogs} />
       <LogColumn title="System" logs={systemLogs} />


### PR DESCRIPTION
## Summary
- add reusable Card and ProgressBar components for consistent styling
- redesign HUD with icons and goal progress bar
- refresh log console layout with responsive grid and memoized columns

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb9a0728548328a82fd8b2f63bcf46