### PR TITLE
feat(client): add log clearing and limit

### DIFF
--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -7,6 +7,8 @@ import { Map3DView } from './ui/map-3d-view';
 import { HUD } from './ui/hud';
 import { MapDef, ServerMessage, GameParams } from '@snail/protocol';
 
+const LOG_LIMIT = 100;
+
 export function App() {
   const [url, setUrl] = useState('localhost:3000');
   const [socket, setSocket] = useState<WebSocket | null>(null);
@@ -47,13 +49,19 @@ export function App() {
     setter: React.Dispatch<React.SetStateAction<LogEntry[]>>,
   ) =>
     (msg: string) =>
-      setter((l) => [...l, { ts: Date.now(), msg }]);
+      setter((l) => [...l.slice(-LOG_LIMIT + 1), { ts: Date.now(), msg }]);
 
   const logIn = log(setInLogs);
   const logOut = log(setOutLogs);
   const logSys = log(setSystemLogs);
   const logUpkeep = log(setUpkeepLogs);
   const logGoal = log(setGoalLogs);
+
+  const clearInLogs = () => setInLogs([]);
+  const clearOutLogs = () => setOutLogs([]);
+  const clearSystemLogs = () => setSystemLogs([]);
+  const clearUpkeepLogs = () => setUpkeepLogs([]);
+  const clearGoalLogs = () => setGoalLogs([]);
 
   const statusColors: Record<
     'disconnected' | 'connecting' | 'connected' | 'error',
@@ -271,6 +279,11 @@ export function App() {
             systemLogs={systemLogs}
             upkeepLogs={upkeepLogs}
             goalLogs={goalLogs}
+            onClearIn={clearInLogs}
+            onClearOut={clearOutLogs}
+            onClearSystem={clearSystemLogs}
+            onClearUpkeep={clearUpkeepLogs}
+            onClearGoal={clearGoalLogs}
           />
         </div>
       </div>

--- a/apps/client/src/ui/log-console.tsx
+++ b/apps/client/src/ui/log-console.tsx
@@ -10,14 +10,21 @@ interface LogConsoleProps {
   systemLogs: LogEntry[];
   upkeepLogs: LogEntry[];
   goalLogs: LogEntry[];
+  onClearIn?: () => void;
+  onClearOut?: () => void;
+  onClearSystem?: () => void;
+  onClearUpkeep?: () => void;
+  onClearGoal?: () => void;
 }
 
 const LogColumn = React.memo(function LogColumn({
   title,
   logs,
+  onClear,
 }: {
   title: string;
   logs: LogEntry[];
+  onClear?: () => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -28,7 +35,17 @@ const LogColumn = React.memo(function LogColumn({
 
   return (
     <Card className="h-48 flex flex-col">
-      <h3 className="font-semibold mb-1 text-sm px-2 pt-2">{title}</h3>
+      <h3 className="font-semibold mb-1 text-sm px-2 pt-2 flex justify-between items-center">
+        <span>{title}</span>
+        {onClear && (
+          <button
+            className="text-xs text-dew hover:text-moss"
+            onClick={onClear}
+          >
+            Clear
+          </button>
+        )}
+      </h3>
       <div ref={ref} className="flex-1 overflow-auto px-2 pb-2">
         <ul className="text-xs space-y-1">
           {logs.map((log, i) => (
@@ -51,14 +68,19 @@ export function LogConsole({
   systemLogs,
   upkeepLogs,
   goalLogs,
+  onClearIn,
+  onClearOut,
+  onClearSystem,
+  onClearUpkeep,
+  onClearGoal,
 }: LogConsoleProps) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-5 gap-4 mt-4">
-      <LogColumn title="IN" logs={inLogs} />
-      <LogColumn title="OUT" logs={outLogs} />
-      <LogColumn title="System" logs={systemLogs} />
-      <LogColumn title="Upkeep" logs={upkeepLogs} />
-      <LogColumn title="Goal" logs={goalLogs} />
+      <LogColumn title="IN" logs={inLogs} onClear={onClearIn} />
+      <LogColumn title="OUT" logs={outLogs} onClear={onClearOut} />
+      <LogColumn title="System" logs={systemLogs} onClear={onClearSystem} />
+      <LogColumn title="Upkeep" logs={upkeepLogs} onClear={onClearUpkeep} />
+      <LogColumn title="Goal" logs={goalLogs} onClear={onClearGoal} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add clear callbacks and buttons for each log console column
- reset log arrays from app and enforce a global log limit

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bba09e45688328876f1ae0a5f10f66