### PR TITLE
feat(client): add resource bar

### DIFF
--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -5,6 +5,7 @@ import { LogConsole, LogEntry } from './ui/log-console';
 import { MapView } from './ui/map-view';
 import { Map3DView } from './ui/map-3d-view';
 import { HUD } from './ui/hud';
+import { ResourceBar, type Resources } from './ui/resource-bar';
 import { MapDef, ServerMessage, GameParams } from '@snail/protocol';
 
 const LOG_LIMIT = 100;
@@ -27,9 +28,9 @@ export function App() {
   const [systemLogs, setSystemLogs] = useState<LogEntry[]>([]);
   const [upkeepLogs, setUpkeepLogs] = useState<LogEntry[]>([]);
   const [goalLogs, setGoalLogs] = useState<LogEntry[]>([]);
-  const [inventory, setInventory] = useState<{ water?: number; biomass?: number } | null>(
-    null,
-  );
+  const [inventory, setInventory] = useState<
+    (Resources & { biomass?: number }) | null
+  >(null);
   const [goalProgress, setGoalProgress] = useState<{
     active: number;
     required: number;
@@ -132,7 +133,7 @@ export function App() {
         setMap(msg.map);
         setSnapshot({ t: 'State', entities: msg.entities });
         setParams(msg.params);
-        setInventory(msg.params.resources ?? null);
+        setInventory((msg.params.resources as Resources & { biomass?: number }) ?? null);
         logUpkeep(
           `Base W:${msg.params.resources?.water ?? 0} B:${
             msg.params.resources?.biomass ?? 0
@@ -178,8 +179,12 @@ export function App() {
   };
 
   return (
-    <div className="p-4 min-h-screen">
-      <h1 className="text-xl font-bold mb-2 text-glow">SnailColony</h1>
+    <>
+      <div className="fixed top-0 left-0 right-0">
+        <ResourceBar resources={inventory ?? {}} />
+      </div>
+      <div className="p-4 pt-16 min-h-screen">
+        <h1 className="text-xl font-bold mb-2 text-glow">SnailColony</h1>
       <div
         className={`mb-2 p-1 text-center ${statusColors[connectionStatus]}`}
       >
@@ -288,5 +293,6 @@ export function App() {
         </div>
       </div>
     </div>
+    </>
   );
 }

--- a/apps/client/src/assets/leaves.svg
+++ b/apps/client/src/assets/leaves.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="#4CAF50" d="M12 2C5 9 5 14 12 22c7-8 7-13 0-20z"/>
+</svg>

--- a/apps/client/src/assets/rocks.svg
+++ b/apps/client/src/assets/rocks.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="#9E9E9E" d="M3 17l5-10 6-2 7 12-4 2H7z"/>
+</svg>

--- a/apps/client/src/assets/soil.svg
+++ b/apps/client/src/assets/soil.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect x="2" y="2" width="20" height="20" rx="3" fill="#8B4513"/>
+</svg>

--- a/apps/client/src/assets/water.svg
+++ b/apps/client/src/assets/water.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="#00bcd4" d="M12 2C9 6 5 10 5 14a7 7 0 0014 0c0-4-4-8-7-12z"/>
+</svg>

--- a/apps/client/src/ui/resource-bar.tsx
+++ b/apps/client/src/ui/resource-bar.tsx
@@ -1,0 +1,31 @@
+import waterIcon from '../assets/water.svg';
+import soilIcon from '../assets/soil.svg';
+import leavesIcon from '../assets/leaves.svg';
+import rocksIcon from '../assets/rocks.svg';
+
+export interface Resources {
+  water?: number;
+  soil?: number;
+  leaves?: number;
+  rocks?: number;
+}
+
+export function ResourceBar({ resources }: { resources: Resources }) {
+  const items = [
+    { key: 'water', icon: waterIcon, alt: 'Water' },
+    { key: 'soil', icon: soilIcon, alt: 'Soil' },
+    { key: 'leaves', icon: leavesIcon, alt: 'Leaves' },
+    { key: 'rocks', icon: rocksIcon, alt: 'Rocks' },
+  ] as const;
+
+  return (
+    <div className="flex gap-4 bg-soil text-dew p-2">
+      {items.map(({ key, icon, alt }) => (
+        <div key={key} className="flex items-center gap-1">
+          <img src={icon} alt={alt} className="w-4 h-4" />
+          <span>{resources[key] ?? 0}</span>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add ResourceBar component with icons for water, soil, leaves, and rocks
- show ResourceBar at the top of the client app and populate it with server resources

## Testing
- `pnpm --filter @snail/client lint`
- `pnpm --filter @snail/client test`


------
https://chatgpt.com/codex/tasks/task_e_68bba2b10d688328a89113a4fbbfb7b4