### PR TITLE
feat: refresh theme with stone palette

### DIFF
--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -77,10 +77,10 @@ export function App() {
     'disconnected' | 'connecting' | 'connected' | 'error',
     string
   > = {
-    disconnected: 'bg-soil text-dew',
-    connecting: 'bg-dew text-soil',
-    connected: 'bg-moss text-dew',
-    error: 'bg-amber text-soil',
+    disconnected: 'bg-stone-700 text-sage-100',
+    connecting: 'bg-sage-400 text-stone-900',
+    connected: 'bg-sage-700 text-stone-100',
+    error: 'bg-brown-600 text-stone-100',
   };
   const statusIcons: Record<
     'disconnected' | 'connecting' | 'connected' | 'error',
@@ -203,7 +203,7 @@ export function App() {
         <ResourceBar resources={inventory ?? {}} />
       </div>
       {activePanel && (
-        <div className="fixed right-2 top-2 bg-stone-800/90 p-4 rounded shadow text-dew">
+        <div className="fixed right-2 top-2">
           {activePanel.type === 'colony' && (
             <ColonyPanel
               name={activePanel.name}
@@ -234,32 +234,32 @@ export function App() {
       {map && <HUD inventory={inventory} goal={goalProgress} />}
       <div className="mb-2">
         <input
-          className="border border-dew bg-soil p-1 mr-2"
+          className="border border-stone-700 bg-stone-800 text-sage-100 p-1 mr-2"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
         />
         <input
-          className="border border-dew bg-soil p-1 mr-2"
+          className="border border-stone-700 bg-stone-800 text-sage-100 p-1 mr-2"
           placeholder="Name"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <button
-          className="bg-glow text-soil px-2 mr-2"
+          className="bg-sage-500 text-stone-900 px-2 mr-2 border border-stone-700 shadow"
           onClick={connect}
           disabled={!!socket || !name}
         >
           Connect
         </button>
         <button
-          className="bg-amber text-soil px-2 mr-2"
+          className="bg-brown-600 text-stone-100 px-2 mr-2 border border-stone-700 shadow"
           onClick={disconnect}
           disabled={!socket}
         >
           Disconnect
         </button>
         <button
-          className="bg-moss text-dew px-2 mr-2"
+          className="bg-sage-700 text-sage-100 px-2 mr-2 border border-stone-700 shadow"
           onClick={toggleReady}
           disabled={!socket || !lobby || lobby.started}
         >
@@ -267,7 +267,7 @@ export function App() {
         </button>
         {map && (
           <button
-            className="bg-dew text-soil px-2 ml-2"
+            className="bg-sage-400 text-stone-900 px-2 ml-2 border border-stone-700 shadow"
             onClick={() => setVoxel((v) => !v)}
           >
             {voxel ? '2D View' : '3D View'}
@@ -277,7 +277,7 @@ export function App() {
       {isDev && (
         <div className="mb-2">
           <button
-            className="bg-glow text-soil px-2 mr-2"
+            className="bg-sage-500 text-stone-900 px-2 mr-2 border border-stone-700 shadow"
             onClick={() =>
               setActivePanel({ type: 'colony', name: 'Demo Colony', stars: 3 })
             }
@@ -285,7 +285,7 @@ export function App() {
             Show Colony
           </button>
           <button
-            className="bg-glow text-soil px-2"
+            className="bg-sage-500 text-stone-900 px-2 border border-stone-700 shadow"
             onClick={() =>
               setActivePanel({ type: 'snail', name: 'Demo Snail', stars: 2 })
             }
@@ -295,7 +295,7 @@ export function App() {
         </div>
       )}
       {connectionStatus === 'connected' && latency !== null && (
-        <p className="text-sm text-dew">Latency: {latency} ms</p>
+        <p className="text-sm text-sage-100">Latency: {latency} ms</p>
       )}
       {!map && lobby && !lobby.started && (
         <div className="mt-4">

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply bg-soil text-dew font-sans;
+  @apply bg-stone-900 text-sage-100 font-serif;
 }

--- a/apps/client/src/ui/colony-panel.tsx
+++ b/apps/client/src/ui/colony-panel.tsx
@@ -6,11 +6,11 @@ interface ColonyPanelProps {
 
 export function ColonyPanel({ name, stars, onClose }: ColonyPanelProps) {
   return (
-    <div className="min-w-[200px] text-dew">
+    <div className="min-w-[200px] text-sage-100 bg-stone-800/90 p-4 rounded border border-stone-700 shadow">
       <div className="flex items-center justify-between mb-2">
         <h2 className="text-lg font-bold">{name}</h2>
         <button
-          className="px-2 text-dew hover:text-amber"
+          className="px-2 text-sage-100 hover:text-brown-400"
           onClick={onClose}
           aria-label="Close"
         >
@@ -23,8 +23,12 @@ export function ColonyPanel({ name, stars, onClose }: ColonyPanelProps) {
         ))}
       </div>
       <div className="flex gap-2">
-        <button className="bg-moss text-soil px-2 py-1 rounded">Upgrade</button>
-        <button className="bg-amber text-soil px-2 py-1 rounded">Abandon</button>
+        <button className="bg-sage-700 text-stone-100 px-2 py-1 rounded border border-stone-700 shadow">
+          Upgrade
+        </button>
+        <button className="bg-brown-600 text-stone-100 px-2 py-1 rounded border border-stone-700 shadow">
+          Abandon
+        </button>
       </div>
     </div>
   );

--- a/apps/client/src/ui/components.tsx
+++ b/apps/client/src/ui/components.tsx
@@ -4,7 +4,9 @@ export const Card: React.FC<React.PropsWithChildren<{ className?: string }>> = (
   children,
   className = '',
 }) => (
-  <div className={`bg-white/80 backdrop-blur border rounded shadow-sm ${className}`}>
+  <div
+    className={`bg-stone-800/80 backdrop-blur border border-stone-700 rounded shadow ${className}`}
+  >
     {children}
   </div>
 );

--- a/apps/client/src/ui/log-console.tsx
+++ b/apps/client/src/ui/log-console.tsx
@@ -39,7 +39,7 @@ const LogColumn = React.memo(function LogColumn({
         <span>{title}</span>
         {onClear && (
           <button
-            className="text-xs text-dew hover:text-moss"
+            className="text-xs text-sage-100 hover:text-sage-300"
             onClick={onClear}
           >
             Clear
@@ -50,7 +50,7 @@ const LogColumn = React.memo(function LogColumn({
         <ul className="text-xs space-y-1">
           {logs.map((log, i) => (
             <li key={i}>
-              <span className="text-gray-500 mr-1">
+              <span className="text-stone-400 mr-1">
                 {new Date(log.ts).toLocaleTimeString()}
               </span>
               {log.msg}

--- a/apps/client/src/ui/resource-bar.tsx
+++ b/apps/client/src/ui/resource-bar.tsx
@@ -19,7 +19,7 @@ export function ResourceBar({ resources }: { resources: Resources }) {
   ] as const;
 
   return (
-    <div className="flex gap-4 bg-soil text-dew p-2">
+    <div className="flex gap-4 bg-stone-800 text-sage-100 p-2 border border-stone-700 rounded shadow">
       {items.map(({ key, icon, alt }) => (
         <div key={key} className="flex items-center gap-1">
           <img src={icon} alt={alt} className="w-4 h-4" />

--- a/apps/client/src/ui/snail-panel.tsx
+++ b/apps/client/src/ui/snail-panel.tsx
@@ -6,11 +6,11 @@ interface SnailPanelProps {
 
 export function SnailPanel({ name, stars, onClose }: SnailPanelProps) {
   return (
-    <div className="min-w-[200px] text-dew">
+    <div className="min-w-[200px] text-sage-100 bg-stone-800/90 p-4 rounded border border-stone-700 shadow">
       <div className="flex items-center justify-between mb-2">
         <h2 className="text-lg font-bold">{name}</h2>
         <button
-          className="px-2 text-dew hover:text-amber"
+          className="px-2 text-sage-100 hover:text-brown-400"
           onClick={onClose}
           aria-label="Close"
         >
@@ -23,8 +23,12 @@ export function SnailPanel({ name, stars, onClose }: SnailPanelProps) {
         ))}
       </div>
       <div className="flex gap-2">
-        <button className="bg-dew text-soil px-2 py-1 rounded">Feed</button>
-        <button className="bg-moss text-soil px-2 py-1 rounded">Explore</button>
+        <button className="bg-sage-600 text-stone-100 px-2 py-1 rounded border border-stone-700 shadow">
+          Feed
+        </button>
+        <button className="bg-sage-700 text-stone-100 px-2 py-1 rounded border border-stone-700 shadow">
+          Explore
+        </button>
       </div>
     </div>
   );

--- a/apps/client/tailwind.config.ts
+++ b/apps/client/tailwind.config.ts
@@ -1,3 +1,5 @@
+import colors from 'tailwindcss/colors';
+
 export default {
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
   theme: {
@@ -8,9 +10,35 @@ export default {
         dew: '#4AAFD9',
         glow: '#1DE9B6',
         amber: '#FFC107',
+        stone: colors.stone,
+        sage: {
+          50: '#f1f5f3',
+          100: '#dfe7e5',
+          200: '#c4d3ce',
+          300: '#a2b8b0',
+          400: '#8aa19a',
+          500: '#6f8680',
+          600: '#586c66',
+          700: '#445451',
+          800: '#343f3e',
+          900: '#262e2d',
+        },
+        brown: {
+          50: '#efebe9',
+          100: '#d7ccc8',
+          200: '#bcaaa4',
+          300: '#a1887f',
+          400: '#8d6e63',
+          500: '#795548',
+          600: '#6d4c41',
+          700: '#5d4037',
+          800: '#4e342e',
+          900: '#3e2723',
+        },
       },
       fontFamily: {
         sans: ['Nunito', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        serif: ['ui-serif', 'Georgia', 'serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- add stone, sage, and brown palettes with serif font
- switch default game styles to stone background and sage text
- restyle cards, resource bar, panels and controls with borders and shadows

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5a047f348328bc32d6a5fd180bc7