### PR TITLE
Add snail stats panel icons and star rating

### DIFF
--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -9,6 +9,7 @@ import { ResourceBar, type Resources } from './ui/resource-bar';
 import { ColonyPanel } from './ui/colony-panel';
 import { SnailPanel } from './ui/snail-panel';
 import { MapDef, ServerMessage, GameParams } from '@snail/protocol';
+import type { Snail } from './game/snail';
 
 const LOG_LIMIT = 100;
 
@@ -49,7 +50,7 @@ export function App() {
   } | null>(null);
   type ActivePanel =
     | { type: 'colony'; name: string; stars: number }
-    | { type: 'snail'; name: string; stars: number }
+    | { type: 'snail'; snail: Snail }
     | null;
   const [activePanel, setActivePanel] = useState<ActivePanel>(null);
   // Default to development mode unless explicitly disabled via VITE_DEV=false
@@ -213,8 +214,7 @@ export function App() {
           )}
           {activePanel.type === 'snail' && (
             <SnailPanel
-              name={activePanel.name}
-              stars={activePanel.stars}
+              snail={activePanel.snail}
               onClose={() => setActivePanel(null)}
             />
           )}
@@ -287,7 +287,18 @@ export function App() {
           <button
             className="bg-glow text-soil px-2"
             onClick={() =>
-              setActivePanel({ type: 'snail', name: 'Demo Snail', stars: 2 })
+              setActivePanel({
+                type: 'snail',
+                snail: {
+                  name: 'Demo Snail',
+                  stars: 2,
+                  brain: 1,
+                  speed: 2,
+                  shell: 3,
+                  storage: 4,
+                  sync: 2,
+                },
+              })
             }
           >
             Show Snail

--- a/apps/client/src/assets/icons/brain.svg
+++ b/apps/client/src/assets/icons/brain.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <circle cx="8" cy="12" r="5"/>
+  <circle cx="16" cy="12" r="5"/>
+</svg>

--- a/apps/client/src/assets/icons/shell.svg
+++ b/apps/client/src/assets/icons/shell.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M12 5a7 7 0 100 14 3 3 0 100-6 1 1 0 100 2"/>
+</svg>

--- a/apps/client/src/assets/icons/speed.svg
+++ b/apps/client/src/assets/icons/speed.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M4 4l12 8-12 8z"/>
+</svg>

--- a/apps/client/src/assets/icons/storage.svg
+++ b/apps/client/src/assets/icons/storage.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <rect x="4" y="4" width="16" height="16" rx="2"/>
+</svg>

--- a/apps/client/src/assets/icons/sync.svg
+++ b/apps/client/src/assets/icons/sync.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+  <path d="M3 12a9 9 0 0114.14-7.32L19 3M21 12a9 9 0 01-14.14 7.32L5 21"/>
+</svg>

--- a/apps/client/src/game/snail.ts
+++ b/apps/client/src/game/snail.ts
@@ -1,0 +1,9 @@
+export interface Snail {
+  name: string;
+  stars: number;
+  brain: number;
+  speed: number;
+  shell: number;
+  storage: number;
+  sync: number;
+}

--- a/apps/client/src/ui/colony-panel.tsx
+++ b/apps/client/src/ui/colony-panel.tsx
@@ -1,3 +1,5 @@
+import { StarRating } from './components';
+
 interface ColonyPanelProps {
   name: string;
   stars: number;
@@ -18,9 +20,7 @@ export function ColonyPanel({ name, stars, onClose }: ColonyPanelProps) {
         </button>
       </div>
       <div className="mb-4">
-        {Array.from({ length: stars }).map((_, i) => (
-          <span key={i}>⭐</span>
-        ))}
+        <StarRating stars={stars} />
       </div>
       <div className="flex gap-2">
         <button className="bg-moss text-soil px-2 py-1 rounded">Upgrade</button>

--- a/apps/client/src/ui/components.tsx
+++ b/apps/client/src/ui/components.tsx
@@ -23,3 +23,17 @@ export function ProgressBar({ value, color = 'bg-green-500' }: ProgressBarProps)
   );
 }
 
+interface StarRatingProps {
+  stars: number;
+}
+
+export function StarRating({ stars }: StarRatingProps) {
+  return (
+    <div>
+      {Array.from({ length: stars }).map((_, i) => (
+        <span key={i}>⭐</span>
+      ))}
+    </div>
+  );
+}
+

--- a/apps/client/src/ui/snail-panel.tsx
+++ b/apps/client/src/ui/snail-panel.tsx
@@ -1,14 +1,29 @@
+import brainIcon from '../assets/icons/brain.svg';
+import speedIcon from '../assets/icons/speed.svg';
+import shellIcon from '../assets/icons/shell.svg';
+import storageIcon from '../assets/icons/storage.svg';
+import syncIcon from '../assets/icons/sync.svg';
+import { Snail } from '../game/snail';
+import { StarRating } from './components';
+
 interface SnailPanelProps {
-  name: string;
-  stars: number;
+  snail: Snail;
   onClose: () => void;
 }
 
-export function SnailPanel({ name, stars, onClose }: SnailPanelProps) {
+export function SnailPanel({ snail, onClose }: SnailPanelProps) {
+  const stats = [
+    { label: 'Brain', icon: brainIcon, value: snail.brain },
+    { label: 'Speed', icon: speedIcon, value: snail.speed },
+    { label: 'Shell', icon: shellIcon, value: snail.shell },
+    { label: 'Storage', icon: storageIcon, value: snail.storage },
+    { label: 'Sync', icon: syncIcon, value: snail.sync },
+  ];
+
   return (
     <div className="min-w-[200px] text-dew">
       <div className="flex items-center justify-between mb-2">
-        <h2 className="text-lg font-bold">{name}</h2>
+        <h2 className="text-lg font-bold">{snail.name}</h2>
         <button
           className="px-2 text-dew hover:text-amber"
           onClick={onClose}
@@ -18,10 +33,18 @@ export function SnailPanel({ name, stars, onClose }: SnailPanelProps) {
         </button>
       </div>
       <div className="mb-4">
-        {Array.from({ length: stars }).map((_, i) => (
-          <span key={i}>⭐</span>
-        ))}
+        <StarRating stars={snail.stars} />
       </div>
+      <ul className="mb-4 space-y-1">
+        {stats.map((s) => (
+          <li key={s.label} className="flex items-center gap-1">
+            <img src={s.icon} alt={s.label} className="w-4 h-4" />
+            <span>
+              {s.label}: {s.value}
+            </span>
+          </li>
+        ))}
+      </ul>
       <div className="flex gap-2">
         <button className="bg-dew text-soil px-2 py-1 rounded">Feed</button>
         <button className="bg-moss text-soil px-2 py-1 rounded">Explore</button>
@@ -29,4 +52,3 @@ export function SnailPanel({ name, stars, onClose }: SnailPanelProps) {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- add SVG icons for snail skills
- show snail stats with icons in panel
- introduce reusable StarRating component

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm --filter @snail/client build`


------
https://chatgpt.com/codex/tasks/task_e_68bc5e7e127483288ec9171478dbd59e