### PR TITLE
refactor: use Card for overlay panels

### DIFF
--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -8,6 +8,7 @@ import { HUD } from './ui/hud';
 import { ResourceBar, type Resources } from './ui/resource-bar';
 import { ColonyPanel } from './ui/colony-panel';
 import { SnailPanel } from './ui/snail-panel';
+import { Card } from './ui/components';
 import { MapDef, ServerMessage, GameParams } from '@snail/protocol';
 import type { Snail } from './game/snail';
 
@@ -260,7 +261,7 @@ export function App() {
       {map && <HUD inventory={inventory} goal={goalProgress} />}
 
       {activePanel && (
-        <div className="absolute right-2 top-2 bg-stone-800/90 p-4 rounded shadow text-dew z-30">
+        <Card className="absolute right-2 top-2 p-4 z-30 min-w-[200px]">
           {activePanel.type === 'colony' && (
             <ColonyPanel
               name={activePanel.name}
@@ -274,7 +275,7 @@ export function App() {
               onClose={() => setActivePanel(null)}
             />
           )}
-        </div>
+        </Card>
       )}
       {menuOpen && (
         <div className="absolute top-16 left-2 bg-stone-800/90 p-4 rounded shadow text-dew z-30 space-y-2 max-w-md">

--- a/apps/client/src/ui/colony-panel.tsx
+++ b/apps/client/src/ui/colony-panel.tsx
@@ -8,11 +8,11 @@ interface ColonyPanelProps {
 
 export function ColonyPanel({ name, stars, onClose }: ColonyPanelProps) {
   return (
-    <div className="min-w-[200px] text-dew">
+    <div>
       <div className="flex items-center justify-between mb-2">
         <h2 className="text-lg font-bold">{name}</h2>
         <button
-          className="px-2 text-dew hover:text-amber"
+          className="px-2 hover:text-amber"
           onClick={onClose}
           aria-label="Close"
         >

--- a/apps/client/src/ui/snail-panel.tsx
+++ b/apps/client/src/ui/snail-panel.tsx
@@ -21,11 +21,11 @@ export function SnailPanel({ snail, onClose }: SnailPanelProps) {
   ];
 
   return (
-    <div className="min-w-[200px] text-dew">
+    <div>
       <div className="flex items-center justify-between mb-2">
         <h2 className="text-lg font-bold">{snail.name}</h2>
         <button
-          className="px-2 text-dew hover:text-amber"
+          className="px-2 hover:text-amber"
           onClick={onClose}
           aria-label="Close"
         >


### PR DESCRIPTION
## Summary
- swap ad-hoc overlay div for shared Card component
- streamline snail and colony panel styles

## Testing
- `pnpm --filter @snail/client lint` *(fails: ESLint couldn't find configuration file)*
- `pnpm --filter @snail/client test` *(fails: vitest not found)*
- `pnpm --filter @snail/client dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bca3621ebc8328ba8269ff97c3def8