### PR TITLE
feat: improve client HUD responsiveness

### DIFF
--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -261,7 +261,9 @@ export function App() {
       {map && <HUD inventory={inventory} goal={goalProgress} />}
 
       {activePanel && (
-        <Card className="absolute right-2 top-2 p-4 z-30 min-w-[200px]">
+        <Card
+          className="absolute top-2 left-1/2 -translate-x-1/2 w-[calc(100%-1rem)] sm:left-auto sm:right-2 sm:translate-x-0 sm:w-auto p-4 z-30 min-w-[200px] md:min-w-[250px]"
+        >
           {activePanel.type === 'colony' && (
             <ColonyPanel
               name={activePanel.name}
@@ -278,7 +280,7 @@ export function App() {
         </Card>
       )}
       {menuOpen && (
-        <div className="absolute top-16 left-2 bg-stone-800/90 p-4 rounded shadow text-dew z-30 space-y-2 max-w-md">
+        <div className="absolute top-16 left-1/2 -translate-x-1/2 w-[calc(100%-1rem)] sm:left-2 sm:translate-x-0 sm:w-auto bg-stone-800/90 p-4 rounded shadow text-dew z-30 space-y-2 max-w-md md:max-w-lg">
           <h1 className="text-xl font-bold mb-2 text-glow">SnailColony</h1>
           <div className={`p-1 text-center ${statusColors[connectionStatus]}`}>
             <span className="mr-1">{statusIcons[connectionStatus]}</span>
@@ -389,7 +391,7 @@ export function App() {
       )}
 
       {/* Logs overlay */}
-      <div className="absolute bottom-2 left-2 z-30 max-w-[90vw]">
+      <div className="absolute bottom-2 left-1/2 -translate-x-1/2 w-[calc(100%-1rem)] sm:left-2 sm:translate-x-0 sm:w-auto z-30 max-w-[90vw] sm:max-w-sm md:max-w-md">
         <LogConsole
           inLogs={inLogs}
           outLogs={outLogs}

--- a/apps/client/src/ui/hud.tsx
+++ b/apps/client/src/ui/hud.tsx
@@ -20,9 +20,11 @@ export function HUD({ inventory, goal }: HUDProps) {
   const goalProgress = goal ? goal.sustain_seconds / goal.sustain_required : 0;
 
   return (
-    <Card className="fixed top-2 left-1/2 -translate-x-1/2 px-4 py-2 text-sm space-y-2 min-w-[240px] z-10">
+    <Card
+      className="fixed top-2 left-1/2 -translate-x-1/2 z-10 w-[calc(100%-1rem)] sm:w-auto sm:min-w-[240px] md:min-w-[300px] px-2 sm:px-4 py-2 text-sm flex flex-col sm:flex-row sm:items-center sm:space-x-4 space-y-2 sm:space-y-0"
+    >
       {inventory && (
-        <div className="flex items-center justify-around text-center">
+        <div className="flex items-center justify-around text-center sm:flex-1 sm:justify-center sm:gap-4">
           <div className="flex items-center space-x-1">
             <span className="font-semibold">💧</span>
             <span>{inventory.water ?? 0}</span>
@@ -34,7 +36,7 @@ export function HUD({ inventory, goal }: HUDProps) {
         </div>
       )}
       {goal && (
-        <div className="space-y-1">
+        <div className="space-y-1 sm:flex-1">
           <div className="flex justify-between text-xs">
             <span>
               Colonies {goal.active}/{goal.required}


### PR DESCRIPTION
## Summary
- make HUD bar responsive with mobile-first layout
- add responsive widths and centering to menu and log overlays

## Testing
- `pnpm --filter @snail/client lint`
- `pnpm --filter @snail/client test`
- `pnpm --filter @snail/client dev` *(fails: Failed to resolve entry for package "@snail/protocol"; could not verify layout in browser)*

------
https://chatgpt.com/codex/tasks/task_e_68bca58f1c148328a2c9198b027c6a1e