### PR TITLE
feat(client): add reusable button component

### DIFF
--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -9,7 +9,7 @@ import { HUD } from './ui/hud';
 import { ResourceBar, type Resources } from './ui/resource-bar';
 import { ColonyPanel } from './ui/colony-panel';
 import { SnailPanel } from './ui/snail-panel';
-import { Card } from './ui/components';
+import { Card, Button } from './ui/components';
 import { MapDef, ServerMessage, GameParams } from '@snail/protocol';
 import type { Snail } from './game/snail';
 
@@ -250,12 +250,12 @@ export function App() {
       {/* Resource bar and menu button */}
       <div className="absolute top-0 left-0 right-0 z-20">
         <ResourceBar resources={inventory ?? {}} />
-        <button
-          className="absolute top-2 right-2 bg-stone-800/90 px-2 py-1 rounded text-dew-dark"
+        <Button
+          className="absolute top-2 right-2"
           onClick={() => setMenuOpen((m) => !m)}
         >
           Menu
-        </button>
+        </Button>
       </div>
 
       {/* Overlays */}
@@ -321,36 +321,40 @@ export function App() {
                 />
               </div>
               <div>
-                <button
-                  className="bg-glow text-soil-light px-2 mr-2"
+                <Button
+                  variant="danger"
+                  className="mr-2"
                   onClick={connect}
                   disabled={!!socket || !name}
                 >
                   Connect
-                </button>
-                <button
-                  className="bg-amber text-soil-light px-2 mr-2"
+                </Button>
+                <Button
+                  variant="warning"
+                  className="mr-2"
                   onClick={disconnect}
                   disabled={!socket}
                 >
                   Disconnect
-                </button>
-              <button
-                className="bg-moss text-dew-dark px-2 mr-2"
-                onClick={toggleReady}
-                disabled={!socket || !lobby || lobby.started}
-              >
-                {ready ? 'Unready' : 'Ready'}
-              </button>
-              {map && (
-                <button
-                  className="bg-dew-dark text-soil-light px-2 ml-2"
-                  onClick={() => setVoxel((v) => !v)}
+                </Button>
+                <Button
+                  variant="primary"
+                  className="mr-2"
+                  onClick={toggleReady}
+                  disabled={!socket || !lobby || lobby.started}
                 >
-                  {voxel ? '2D View' : '3D View'}
-                </button>
-              )}
-            </div>
+                  {ready ? 'Unready' : 'Ready'}
+                </Button>
+                {map && (
+                  <Button
+                    variant="secondary"
+                    className="ml-2"
+                    onClick={() => setVoxel((v) => !v)}
+                  >
+                    {voxel ? '2D View' : '3D View'}
+                  </Button>
+                )}
+              </div>
             {connectionStatus === 'connected' && latency !== null && (
               <p className="text-sm text-dew-dark">Latency: {latency} ms</p>
             )}
@@ -368,20 +372,21 @@ export function App() {
             )}
             {isDev && (
               <div>
-                <button
-                  className="bg-glow text-soil-light px-2 mr-2"
+                <Button
+                  variant="danger"
+                  className="mr-2"
                   onClick={() =>
                     setActivePanel({ type: 'colony', name: 'Demo Colony', stars: 3 })
                   }
                 >
                   Show Colony
-                </button>
-                <button
-                  className="bg-glow text-soil-light px-2"
+                </Button>
+                <Button
+                  variant="danger"
                   onClick={() => setSelectedSnailId(0)}
                 >
                   Show Snail
-                </button>
+                </Button>
               </div>
             )}
           </div>

--- a/apps/client/src/ui/colony-panel.tsx
+++ b/apps/client/src/ui/colony-panel.tsx
@@ -1,4 +1,4 @@
-import { StarRating } from './components';
+import { StarRating, Button } from './components';
 
 interface ColonyPanelProps {
   name: string;
@@ -11,20 +11,21 @@ export function ColonyPanel({ name, stars, onClose }: ColonyPanelProps) {
     <div>
       <div className="flex items-center justify-between mb-2">
         <h2 className="text-lg font-bold">{name}</h2>
-        <button
-          className="px-2 hover:text-amber"
+        <Button
+          variant="ghost"
           onClick={onClose}
           aria-label="Close"
+          className="hover:text-amber"
         >
           ✕
-        </button>
+        </Button>
       </div>
       <div className="mb-4">
         <StarRating stars={stars} />
       </div>
       <div className="flex gap-2">
-        <button className="bg-moss text-soil-light px-2 py-1 rounded">Upgrade</button>
-        <button className="bg-amber text-soil-light px-2 py-1 rounded">Abandon</button>
+        <Button variant="primary">Upgrade</Button>
+        <Button variant="warning">Abandon</Button>
       </div>
     </div>
   );

--- a/apps/client/src/ui/components.tsx
+++ b/apps/client/src/ui/components.tsx
@@ -1,5 +1,42 @@
 import React from 'react';
 
+type ButtonVariant = 'primary' | 'warning' | 'danger' | 'secondary' | 'ghost';
+
+interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+}
+
+const variantStyles: Record<ButtonVariant, string> = {
+  primary: 'bg-moss text-dew-dark hover:bg-moss/80 focus:ring-moss',
+  warning: 'bg-amber text-soil-light hover:bg-amber/80 focus:ring-amber',
+  danger: 'bg-glow text-soil-light hover:bg-glow/80 focus:ring-glow',
+  secondary: 'bg-dew-dark text-soil-light hover:bg-dew-dark/80 focus:ring-dew-dark',
+  ghost: 'bg-transparent text-dew-dark hover:bg-dew-dark/20 focus:ring-dew-dark',
+};
+
+export function Button({
+  variant = 'secondary',
+  className = '',
+  disabled,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      {...props}
+      disabled={disabled}
+      className={[
+        'px-2 py-1 rounded transition-colors focus:outline-none',
+        !disabled && 'focus:ring-2 focus:ring-offset-2',
+        disabled ? 'opacity-50 cursor-not-allowed' : variantStyles[variant],
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    />
+  );
+}
+
 export const Card: React.FC<React.PropsWithChildren<{ className?: string }>> = ({
   children,
   className = '',

--- a/apps/client/src/ui/snail-panel.tsx
+++ b/apps/client/src/ui/snail-panel.tsx
@@ -4,7 +4,7 @@ import shellIcon from '../assets/icons/shell.svg';
 import storageIcon from '../assets/icons/storage.svg';
 import syncIcon from '../assets/icons/sync.svg';
 import { Snail } from '../game/snail';
-import { StarRating } from './components';
+import { StarRating, Button } from './components';
 
 interface SnailPanelProps {
   snail: Snail;
@@ -24,13 +24,14 @@ export function SnailPanel({ snail, onClose }: SnailPanelProps) {
     <div>
       <div className="flex items-center justify-between mb-2">
         <h2 className="text-lg font-bold">{snail.name}</h2>
-        <button
-          className="px-2 hover:text-amber"
+        <Button
+          variant="ghost"
           onClick={onClose}
           aria-label="Close"
+          className="hover:text-amber"
         >
           ✕
-        </button>
+        </Button>
       </div>
       <div className="mb-4">
         <StarRating stars={snail.stars} />
@@ -46,8 +47,8 @@ export function SnailPanel({ snail, onClose }: SnailPanelProps) {
         ))}
       </ul>
       <div className="flex gap-2">
-        <button className="bg-dew-dark text-soil-light px-2 py-1 rounded">Feed</button>
-        <button className="bg-moss text-soil-light px-2 py-1 rounded">Explore</button>
+        <Button variant="secondary">Feed</Button>
+        <Button variant="primary">Explore</Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- introduce reusable Button with variants, hover states, and disabled styling
- replace raw button elements in app, snail panel, and colony panel

## Testing
- `pnpm --filter @snail/client dev`
- `pnpm --filter @snail/client lint`
- `pnpm --filter @snail/client test`


------
https://chatgpt.com/codex/tasks/task_e_68bcaa7a6928832887e309cdd16e34ad