### PR TITLE
feat: show snail details when selected

### DIFF
--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -207,8 +207,40 @@ export function App() {
   };
 
   useEffect(() => {
+    if (selectedSnailId === null) {
+      setActivePanel(null);
+      return;
+    }
+
+    const entity = snapshot?.entities.find((e) => e.id === selectedSnailId);
+
+    const snail: Snail = entity
+      ? {
+          name: `Snail ${entity.id}`,
+          stars: 1,
+          brain: 0,
+          speed: 0,
+          shell: 0,
+          storage: 0,
+          sync: 0,
+        }
+      : {
+          name: `Snail ${selectedSnailId}`,
+          stars: 1,
+          brain: 0,
+          speed: 0,
+          shell: 0,
+          storage: 0,
+          sync: 0,
+        };
+
+    setActivePanel({ type: 'snail', snail });
+  }, [selectedSnailId, snapshot]);
+
+  useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        setSelectedSnailId(null);
         setActivePanel(null);
       }
     };


### PR DESCRIPTION
## Summary
- open snail details panel when a snail is selected
- clear active panel and selection on Escape

## Testing
- `pnpm --filter @snail/client lint` (fails: ESLint couldn't find eslint.config)
- `pnpm --filter @snail/client test` (fails: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bcab4569ac8328bd11cc001e9a0c71