### PR TITLE
feat: allow colony selection

### DIFF
--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -200,6 +200,17 @@ export function App() {
     socket.send(JSON.stringify(cmd));
   };
 
+  const handleColonySelect = ({
+    name,
+    stars,
+  }: {
+    name: string;
+    stars: number;
+  }) => {
+    setSelectedSnailId(null);
+    setActivePanel({ type: 'colony', name, stars });
+  };
+
   const sendCommand = (cmd: { t: 'Move'; dx: number; dy: number }) => {
     if (!socket) return;
     logOut(JSON.stringify(cmd));
@@ -265,6 +276,7 @@ export function App() {
                 selectedId={selectedSnailId}
                 onSelect={setSelectedSnailId}
                 onCommand={sendCommand}
+                onColonySelect={handleColonySelect}
               />
             ) : (
               <MapView
@@ -273,6 +285,7 @@ export function App() {
                 selectedId={selectedSnailId}
                 onSelect={setSelectedSnailId}
                 onCommand={sendCommand}
+                onColonySelect={handleColonySelect}
               />
             )
           )}


### PR DESCRIPTION
## Summary
- trigger colony select when clicking colony tiles in 2D/3D maps
- surface colony details panel and clear snail selection on selection

## Testing
- `pnpm --filter @snail/client lint`
- `pnpm --filter @snail/client test`

------
https://chatgpt.com/codex/tasks/task_e_68bcbc23ea48832880443173f1414b76