### PR TITLE
Sync SnailPanel with selected unit

### DIFF
--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -223,29 +223,38 @@ export function App() {
       return;
     }
 
-    const entity = snapshot?.entities.find((e) => e.id === selectedSnailId);
+    setActivePanel((current) => {
+      const entity = snapshot?.entities.find((e) => e.id === selectedSnailId);
 
-    const snail: Snail = entity
-      ? {
-          name: `Snail ${entity.id}`,
-          stars: 1,
-          brain: 0,
-          speed: 0,
-          shell: 0,
-          storage: 0,
-          sync: 0,
-        }
-      : {
-          name: `Snail ${selectedSnailId}`,
-          stars: 1,
-          brain: 0,
-          speed: 0,
-          shell: 0,
-          storage: 0,
-          sync: 0,
-        };
+      const snail: Snail = entity
+        ? {
+            id: entity.id,
+            name: `Snail ${entity.id}`,
+            stars: 1,
+            brain: 0,
+            speed: 0,
+            shell: 0,
+            storage: 0,
+            sync: 0,
+          }
+        : {
+            id: selectedSnailId,
+            name: `Snail ${selectedSnailId}`,
+            stars: 1,
+            brain: 0,
+            speed: 0,
+            shell: 0,
+            storage: 0,
+            sync: 0,
+          };
 
-    setActivePanel({ type: 'snail', snail });
+      const currentId =
+        current?.type === 'snail' ? current.snail.id : null;
+      if (currentId === selectedSnailId) {
+        return { ...current, snail };
+      }
+      return { type: 'snail', snail };
+    });
   }, [selectedSnailId, snapshot]);
 
   useEffect(() => {

--- a/apps/client/src/game/snail.ts
+++ b/apps/client/src/game/snail.ts
@@ -1,4 +1,5 @@
 export interface Snail {
+  id: number;
   name: string;
   stars: number;
   brain: number;


### PR DESCRIPTION
## Summary
- track snail identities with an `id` on the `Snail` interface
- update `activePanel` snail when `selectedSnailId` changes so `SnailPanel` shows the correct stats

## Testing
- `pnpm --filter @snail/client lint`
- `pnpm --filter @snail/client test`


------
https://chatgpt.com/codex/tasks/task_e_68bcbd7f4e308328bc9143b12a003ca1