### PR TITLE
feat: clear selections when closing panels

### DIFF
--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -60,6 +60,10 @@ export function App() {
   const [activePanel, setActivePanel] = useState<ActivePanel>(null);
   const [selectedSnailId, setSelectedSnailId] = useState<number | null>(null);
   const [menuOpen, setMenuOpen] = useState(true);
+  const clearSelection = () => {
+    setSelectedSnailId(null);
+    // Future colony-selection state can be reset here
+  };
   // Default to development mode unless explicitly disabled via VITE_DEV=false
   const isDev = import.meta.env.VITE_DEV !== 'false';
 
@@ -190,7 +194,8 @@ export function App() {
     setGoalProgress(null);
     setUpkeepLogs([]);
     setGoalLogs([]);
-    setSelectedSnailId(null);
+    clearSelection();
+    setActivePanel(null);
   };
 
   const toggleReady = () => {
@@ -207,7 +212,7 @@ export function App() {
     name: string;
     stars: number;
   }) => {
-    setSelectedSnailId(null);
+    clearSelection();
     setActivePanel({ type: 'colony', name, stars });
   };
 
@@ -260,7 +265,7 @@ export function App() {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        setSelectedSnailId(null);
+        clearSelection();
         setActivePanel(null);
       }
     };
@@ -331,12 +336,14 @@ export function App() {
                   name={activePanel.name}
                   stars={activePanel.stars}
                   onClose={() => setActivePanel(null)}
+                  clearSelection={clearSelection}
                 />
               )}
               {activePanel.type === 'snail' && (
                 <SnailPanel
                   snail={activePanel.snail}
                   onClose={() => setActivePanel(null)}
+                  clearSelection={clearSelection}
                 />
               )}
             </Card>

--- a/apps/client/src/ui/colony-panel.tsx
+++ b/apps/client/src/ui/colony-panel.tsx
@@ -4,16 +4,20 @@ interface ColonyPanelProps {
   name: string;
   stars: number;
   onClose: () => void;
+  clearSelection: () => void;
 }
 
-export function ColonyPanel({ name, stars, onClose }: ColonyPanelProps) {
+export function ColonyPanel({ name, stars, onClose, clearSelection }: ColonyPanelProps) {
   return (
     <div>
       <div className="flex items-center justify-between mb-2">
         <h2 className="text-lg font-bold">{name}</h2>
         <Button
           variant="ghost"
-          onClick={onClose}
+          onClick={() => {
+            clearSelection();
+            onClose();
+          }}
           aria-label="Close"
           className="hover:text-amber"
         >

--- a/apps/client/src/ui/snail-panel.tsx
+++ b/apps/client/src/ui/snail-panel.tsx
@@ -9,9 +9,10 @@ import { StarRating, Button } from './components';
 interface SnailPanelProps {
   snail: Snail;
   onClose: () => void;
+  clearSelection: () => void;
 }
 
-export function SnailPanel({ snail, onClose }: SnailPanelProps) {
+export function SnailPanel({ snail, onClose, clearSelection }: SnailPanelProps) {
   const stats = [
     { label: 'Brain', icon: brainIcon, value: snail.brain },
     { label: 'Speed', icon: speedIcon, value: snail.speed },
@@ -26,7 +27,10 @@ export function SnailPanel({ snail, onClose }: SnailPanelProps) {
         <h2 className="text-lg font-bold">{snail.name}</h2>
         <Button
           variant="ghost"
-          onClick={onClose}
+          onClick={() => {
+            clearSelection();
+            onClose();
+          }}
           aria-label="Close"
           className="hover:text-amber"
         >


### PR DESCRIPTION
## Summary
- clear selection state when closing snail or colony panels
- provide a reusable `clearSelection` utility in the app

## Testing
- `pnpm --filter @snail/client lint` *(fails: ESLint couldn't find config)*
- `pnpm --filter @snail/client test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbf2371f08328b0651785261c64d2