### PR TITLE
Preserve colony panel when no snail selected

### DIFF
--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -224,7 +224,9 @@ export function App() {
 
   useEffect(() => {
     if (selectedSnailId === null) {
-      setActivePanel(null);
+      setActivePanel((current) =>
+        current?.type === 'snail' ? null : current,
+      );
       return;
     }
 


### PR DESCRIPTION
## Summary
- only clear the active panel when a snail is deselected to keep colony info visible

## Testing
- `pnpm --filter @snail/client lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm --filter @snail/client test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bce525619c8328b6a1104efe46f797