### PR TITLE
feat: add headless LLM client workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Run the server unit tests, including the ECS system specs, with:
 pnpm --filter @snail/server test
 ```
 
+Exercise the headless LLM client workflow tests with:
+
+```bash
+pnpm --filter @snail/llm-client test
+```
+
 To execute the full test suite across all packages:
 
 ```bash

--- a/apps/llm-client/README.md
+++ b/apps/llm-client/README.md
@@ -1,0 +1,63 @@
+# @snail/llm-client
+
+Headless TypeScript client for automating SnailColony matches over WebSockets. The package wraps the
+raw `ws` connection logic from the React app so a programmable "brain" can react to lobby, room, and
+state updates.
+
+## Features
+
+- Normalises SnailColony WebSocket URLs and sends the required `Join`/`SetReady`/`Move` commands.
+- Emits typed callbacks (`LobbyState`, `RoomState`, `State`) for custom AI integrations.
+- Ships with a small scripted brain and CLI runner for local experimentation.
+
+## Installation
+
+From the monorepo root:
+
+```bash
+pnpm install
+pnpm --filter @snail/llm-client build
+```
+
+## Usage
+
+### Programmatic API
+
+```ts
+import { LLMGameClient, createScriptedBrain } from '@snail/llm-client';
+
+const brain = createScriptedBrain();
+const client = new LLMGameClient({
+  url: 'localhost:3000',
+  name: 'CodexBot',
+  brain,
+});
+
+client.onLobbyState((lobby) => {
+  console.log('Lobby players:', lobby.players);
+});
+
+await client.connect();
+```
+
+Implement the `LLMGameBrain` interface to supply your own decision making. Return `Move` commands
+from `onState` or call `context.sendCommand` for direct control.
+
+### CLI runner
+
+The package also includes a thin CLI wrapper that wires the scripted brain to a WebSocket endpoint:
+
+```bash
+pnpm --filter @snail/llm-client exec snail-llm-client --url localhost:3000 --name CodexBot
+```
+
+Use `--help` to list available flags.
+
+## Testing
+
+Run the Vitest suite:
+
+```bash
+pnpm --filter @snail/llm-client test
+```
+

--- a/apps/llm-client/package.json
+++ b/apps/llm-client/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@snail/llm-client",
+  "version": "0.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "snail-llm-client": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "pnpm --filter @snail/protocol build && vitest run"
+  },
+  "dependencies": {
+    "@snail/protocol": "workspace:*",
+    "ws": "^8.18.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/ws": "^8.18.1",
+    "typescript": "^5.4.2",
+    "vitest": "^0.34.6"
+  }
+}

--- a/apps/llm-client/src/brains/sample.ts
+++ b/apps/llm-client/src/brains/sample.ts
@@ -1,0 +1,62 @@
+import type {
+  LLMGameBrain,
+  MoveCommand,
+  RoomStateMessage,
+  StateSnapshotMessage,
+} from '../client';
+
+export interface ScriptedMove extends Omit<MoveCommand, 't'> {}
+
+export interface ScriptedBrainOptions {
+  /**
+   * Sequence of moves issued after successive State messages.
+   */
+  moves?: ScriptedMove[];
+  /**
+   * Optional logger for tracing activity.
+   */
+  log?: (message: string) => void;
+}
+
+const DEFAULT_MOVES: ScriptedMove[] = [
+  { dx: 1, dy: 0 },
+  { dx: 0, dy: 1 },
+  { dx: -1, dy: 0 },
+  { dx: 0, dy: -1 },
+];
+
+/**
+ * Creates a deterministic brain that immediately readies up and cycles through a scripted move list.
+ */
+export function createScriptedBrain(
+  options: ScriptedBrainOptions = {},
+): LLMGameBrain {
+  const moves = options.moves?.length ? options.moves : DEFAULT_MOVES;
+  let index = 0;
+
+  const nextMove = (): MoveCommand => {
+    const move = moves[index % moves.length];
+    index += 1;
+    return { t: 'Move', ...move };
+  };
+
+  const log = options.log ?? (() => undefined);
+
+  return {
+    async onLobbyState(_state, ctx) {
+      log('Received lobby state; setting ready=true');
+      ctx.setReady(true);
+    },
+    async onRoomState(state: RoomStateMessage) {
+      log(
+        `Entered room with map ${state.map.width}x${state.map.height} and ${state.entities.length} entities`,
+      );
+    },
+    async onState(_state: StateSnapshotMessage) {
+      const move = nextMove();
+      log(`Issuing move dx=${move.dx} dy=${move.dy}`);
+      return move;
+    },
+  };
+}
+

--- a/apps/llm-client/src/cli.ts
+++ b/apps/llm-client/src/cli.ts
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+import process from 'node:process';
+
+import { LLMGameClient } from './client';
+import { createScriptedBrain } from './brains/sample';
+
+interface ParsedArgs {
+  url: string;
+  name: string;
+  help: boolean;
+  unknown: string[];
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let url: string | undefined;
+  let name: string | undefined;
+  let help = false;
+  const unknown: string[] = [];
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+      continue;
+    }
+    if ((arg === '--url' || arg === '-u') && i + 1 < argv.length) {
+      url = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if ((arg === '--name' || arg === '-n') && i + 1 < argv.length) {
+      name = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    unknown.push(arg);
+  }
+
+  return {
+    url: url ?? 'localhost:3000',
+    name: name ?? 'CodexBot',
+    help,
+    unknown,
+  };
+}
+
+function printUsage(): void {
+  console.log(`Usage: snail-llm-client [options]\n\n` +
+    `Options:\n` +
+    `  -u, --url <wsUrl>    WebSocket endpoint (default: localhost:3000)\n` +
+    `  -n, --name <name>    Player name announced during Join (default: CodexBot)\n` +
+    `  -h, --help           Show this message`);
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs(process.argv.slice(2));
+
+  if (parsed.unknown.length > 0) {
+    for (const arg of parsed.unknown) {
+      console.warn(`Ignoring unknown argument: ${arg}`);
+    }
+  }
+
+  if (parsed.help) {
+    printUsage();
+    return;
+  }
+
+  const brain = createScriptedBrain({
+    log: (message) => console.log(`[brain] ${message}`),
+  });
+
+  const client = new LLMGameClient({
+    url: parsed.url,
+    name: parsed.name,
+    brain,
+    logger: {
+      info: (message) => console.log(message),
+      error: (message, error) => console.error(message, error),
+    },
+    onClose: (code, reason) => {
+      const reasonText = reason.toString('utf8');
+      console.log(
+        `Connection closed (code=${code})${reasonText ? `: ${reasonText}` : ''}`,
+      );
+    },
+    onError: (error) => {
+      console.error('WebSocket error encountered:', error);
+    },
+  });
+
+  client.onLobbyState((state) => {
+    const status = state.players
+      .map((player) => `${player.name}${player.ready ? '✅' : '❌'}`)
+      .join(', ');
+    console.log(`[lobby] players: ${status}`);
+  });
+
+  client.onRoomState((state) => {
+    console.log(
+      `[room] map=${state.map.width}x${state.map.height} entities=${state.entities.length}`,
+    );
+  });
+
+  client.onState((state) => {
+    console.log(`[state] tick with ${state.entities.length} entities`);
+  });
+
+  await client.connect();
+
+  console.log(
+    `Connected to ${parsed.url} as ${parsed.name}. Press Ctrl+C to disconnect.`,
+  );
+
+  const shutdown = () => {
+    console.log('Shutting down client...');
+    client.close();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+main().catch((error) => {
+  console.error('Fatal error in LLM client CLI:', error);
+  process.exit(1);
+});
+

--- a/apps/llm-client/src/client.ts
+++ b/apps/llm-client/src/client.ts
@@ -1,0 +1,363 @@
+import NodeWebSocket, { RawData } from 'ws';
+import type { ClientCommand, ServerMessage } from '@snail/protocol';
+
+export type LobbyStateMessage = Extract<ServerMessage, { t: 'LobbyState' }>;
+export type RoomStateMessage = Extract<ServerMessage, { t: 'RoomState' }>;
+export type StateSnapshotMessage = Extract<ServerMessage, { t: 'State' }>;
+export type MoveCommand = Extract<ClientCommand, { t: 'Move' }>;
+
+export type Awaitable<T> = T | Promise<T>;
+
+export interface BrainContext {
+  setReady: (ready: boolean) => void;
+  sendCommand: (command: ClientCommand) => void;
+}
+
+export interface LLMGameBrain {
+  onLobbyState?: (
+    state: LobbyStateMessage,
+    context: BrainContext,
+  ) => Awaitable<void | boolean | { ready: boolean }>;
+  onRoomState?: (
+    state: RoomStateMessage,
+    context: BrainContext,
+  ) => Awaitable<void>;
+  onState?: (
+    state: StateSnapshotMessage,
+    context: BrainContext,
+  ) => Awaitable<void | MoveCommand | MoveCommand[]>;
+}
+
+export interface LLMGameClientOptions {
+  /**
+   * WebSocket endpoint. If the protocol is omitted, `ws://` is assumed and `/ws` is appended when missing.
+   */
+  url: string;
+  /**
+   * Player name announced during the initial Join command.
+   */
+  name: string;
+  /**
+   * Optional LLM brain implementation that reacts to server messages.
+   */
+  brain?: LLMGameBrain;
+  /**
+   * Optional WebSocket implementation, useful for testing.
+   */
+  WebSocketImpl?: typeof NodeWebSocket;
+  /**
+   * Invoked after a successful connection and Join.
+   */
+  onOpen?: () => void;
+  /**
+   * Invoked when the underlying WebSocket closes.
+   */
+  onClose?: (code: number, reason: Buffer) => void;
+  /**
+   * Invoked when the underlying WebSocket emits an error.
+   */
+  onError?: (error: Error) => void;
+  /**
+   * Optional logging hook.
+   */
+  logger?: {
+    info?: (message: string) => void;
+    error?: (message: string, error: unknown) => void;
+  };
+}
+
+function normalizeUrl(url: string): string {
+  let target = url.trim();
+  if (!target.includes('://')) {
+    target = `ws://${target}`;
+  }
+  if (!target.endsWith('/ws')) {
+    target = target.replace(/\/?$/, '/ws');
+  }
+  return target;
+}
+
+export class LLMGameClient {
+  private readonly WebSocketImpl: typeof NodeWebSocket;
+  private socket: NodeWebSocket | null = null;
+  private readonly lobbyHandlers = new Set<
+    (state: LobbyStateMessage) => Awaitable<void>
+  >();
+  private readonly roomHandlers = new Set<
+    (state: RoomStateMessage) => Awaitable<void>
+  >();
+  private readonly stateHandlers = new Set<
+    (state: StateSnapshotMessage) => Awaitable<void>
+  >();
+  private readonly options: LLMGameClientOptions;
+  private readonly brainContext: BrainContext;
+  private hasJoined = false;
+  private lastReadySent: boolean | null = null;
+  private lastLobbyState: LobbyStateMessage | null = null;
+  private lastRoomState: RoomStateMessage | null = null;
+  private lastState: StateSnapshotMessage | null = null;
+
+  constructor(options: LLMGameClientOptions) {
+    this.options = options;
+    this.WebSocketImpl = options.WebSocketImpl ?? NodeWebSocket;
+    this.brainContext = {
+      setReady: (ready: boolean) => this.setReady(ready),
+      sendCommand: (command: ClientCommand) => this.sendCommand(command),
+    };
+  }
+
+  /**
+   * Establishes the WebSocket connection and sends the initial Join command.
+   */
+  async connect(): Promise<void> {
+    if (this.socket) {
+      throw new Error('LLMGameClient is already connected.');
+    }
+
+    const target = normalizeUrl(this.options.url);
+    const socket = new this.WebSocketImpl(target);
+    this.socket = socket;
+
+    await new Promise<void>((resolve, reject) => {
+      const handleOpen = () => {
+        socket.off('error', handleError);
+        socket.on('message', this.handleMessage);
+        socket.on('close', this.handleClose);
+        socket.on('error', this.handleError);
+        try {
+          this.sendCommand({ t: 'Join', name: this.options.name });
+          this.hasJoined = true;
+        } catch (error) {
+          reject(error as Error);
+          return;
+        }
+        this.options.logger?.info?.(
+          `Connected to ${target} as ${this.options.name}`,
+        );
+        this.options.onOpen?.();
+        resolve();
+      };
+
+      const handleError = (error: Error) => {
+        socket.off('open', handleOpen);
+        socket.off('message', this.handleMessage);
+        socket.off('close', this.handleClose);
+        this.socket = null;
+        reject(error);
+      };
+
+      socket.once('open', handleOpen);
+      socket.once('error', handleError);
+    });
+  }
+
+  /**
+   * Gracefully closes the WebSocket connection.
+   */
+  close(): void {
+    if (!this.socket) return;
+    this.socket.off('message', this.handleMessage);
+    this.socket.off('close', this.handleClose);
+    this.socket.off('error', this.handleError);
+    this.socket.close();
+    this.socket = null;
+    this.hasJoined = false;
+    this.lastReadySent = null;
+  }
+
+  /**
+   * Registers a handler for LobbyState messages.
+   */
+  onLobbyState(handler: (state: LobbyStateMessage) => Awaitable<void>): () => void {
+    this.lobbyHandlers.add(handler);
+    return () => this.lobbyHandlers.delete(handler);
+  }
+
+  /**
+   * Registers a handler for RoomState messages.
+   */
+  onRoomState(handler: (state: RoomStateMessage) => Awaitable<void>): () => void {
+    this.roomHandlers.add(handler);
+    return () => this.roomHandlers.delete(handler);
+  }
+
+  /**
+   * Registers a handler for State snapshots.
+   */
+  onState(
+    handler: (state: StateSnapshotMessage) => Awaitable<void>,
+  ): () => void {
+    this.stateHandlers.add(handler);
+    return () => this.stateHandlers.delete(handler);
+  }
+
+  /**
+   * Sends an arbitrary command to the server.
+   */
+  sendCommand(command: ClientCommand): void {
+    if (!this.socket) {
+      throw new Error('Cannot send command before connecting.');
+    }
+    if (this.socket.readyState !== this.WebSocketImpl.OPEN) {
+      throw new Error('WebSocket is not open.');
+    }
+
+    if (command.t === 'SetReady') {
+      if (this.lastReadySent === command.ready) {
+        return;
+      }
+      this.lastReadySent = command.ready;
+    }
+
+    if (command.t === 'Join') {
+      if (this.hasJoined) {
+        throw new Error('Join command has already been sent.');
+      }
+      this.hasJoined = true;
+    }
+
+    this.socket.send(JSON.stringify(command));
+  }
+
+  /**
+   * Convenience helper for toggling ready state.
+   */
+  setReady(ready: boolean): void {
+    if (this.lastReadySent === ready) {
+      return;
+    }
+    this.sendCommand({ t: 'SetReady', ready });
+  }
+
+  /**
+   * Last received lobby state, if any.
+   */
+  get lobbyState(): LobbyStateMessage | null {
+    return this.lastLobbyState;
+  }
+
+  /**
+   * Last received room state, if any.
+   */
+  get roomState(): RoomStateMessage | null {
+    return this.lastRoomState;
+  }
+
+  /**
+   * Last received simulation snapshot, if any.
+   */
+  get state(): StateSnapshotMessage | null {
+    return this.lastState;
+  }
+
+  private readonly handleMessage = async (data: RawData) => {
+    try {
+      const json = typeof data === 'string' ? data : data.toString();
+      const message = JSON.parse(json) as ServerMessage;
+      await this.dispatchMessage(message);
+    } catch (error) {
+      this.options.logger?.error?.('Failed to process server message', error);
+    }
+  };
+
+  private readonly handleClose = (code: number, reason: Buffer) => {
+    if (this.socket) {
+      this.socket.off('message', this.handleMessage);
+      this.socket.off('error', this.handleError);
+      this.socket.off('close', this.handleClose);
+      this.socket = null;
+    }
+    this.hasJoined = false;
+    this.lastReadySent = null;
+    this.options.onClose?.(code, reason);
+  };
+
+  private readonly handleError = (error: Error) => {
+    this.options.logger?.error?.('WebSocket error', error);
+    this.options.onError?.(error);
+  };
+
+  private async dispatchMessage(message: ServerMessage): Promise<void> {
+    switch (message.t) {
+      case 'LobbyState':
+        this.lastLobbyState = message;
+        await this.notifyHandlers(this.lobbyHandlers, message);
+        await this.invokeLobbyBrain(message);
+        break;
+      case 'RoomState':
+        this.lastRoomState = message;
+        await this.notifyHandlers(this.roomHandlers, message);
+        await this.invokeBrain('onRoomState', message);
+        break;
+      case 'State':
+        this.lastState = message;
+        await this.notifyHandlers(this.stateHandlers, message);
+        await this.invokeStateBrain(message);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async notifyHandlers<
+    TMessage,
+    THandler extends (message: TMessage) => Awaitable<void>,
+  >(handlers: Set<THandler>, message: TMessage): Promise<void> {
+    for (const handler of handlers) {
+      await handler(message);
+    }
+  }
+
+  private async invokeLobbyBrain(message: LobbyStateMessage): Promise<void> {
+    const { brain } = this.options;
+    if (!brain?.onLobbyState) return;
+    try {
+      const result = await brain.onLobbyState(message, this.brainContext);
+      if (typeof result === 'boolean') {
+        this.setReady(result);
+      } else if (result && typeof result === 'object' && 'ready' in result) {
+        const { ready } = result as { ready: unknown };
+        if (typeof ready === 'boolean') {
+          this.setReady(ready);
+        }
+      }
+    } catch (error) {
+      this.options.logger?.error?.('Brain onLobbyState failed', error);
+    }
+  }
+
+  private async invokeBrain<T extends keyof LLMGameBrain>(
+    key: T,
+    message: Parameters<NonNullable<LLMGameBrain[T]>>[0],
+  ): Promise<void> {
+    const brain = this.options.brain;
+    const handler = brain?.[key];
+    if (!handler) return;
+    try {
+      await (handler as (
+        state: typeof message,
+        context: BrainContext,
+      ) => Awaitable<void>)(message, this.brainContext);
+    } catch (error) {
+      this.options.logger?.error?.(`Brain ${String(key)} failed`, error);
+    }
+  }
+
+  private async invokeStateBrain(
+    message: StateSnapshotMessage,
+  ): Promise<void> {
+    const brain = this.options.brain;
+    if (!brain?.onState) return;
+    try {
+      const result = await brain.onState(message, this.brainContext);
+      if (!result) return;
+      const commands = Array.isArray(result) ? result : [result];
+      for (const command of commands) {
+        this.sendCommand(command);
+      }
+    } catch (error) {
+      this.options.logger?.error?.('Brain onState failed', error);
+    }
+  }
+}
+

--- a/apps/llm-client/src/index.ts
+++ b/apps/llm-client/src/index.ts
@@ -1,0 +1,16 @@
+export {
+  LLMGameClient,
+  type LLMGameBrain,
+  type BrainContext,
+  type LobbyStateMessage,
+  type RoomStateMessage,
+  type StateSnapshotMessage,
+  type MoveCommand,
+} from './client';
+
+export {
+  createScriptedBrain,
+  type ScriptedBrainOptions,
+  type ScriptedMove,
+} from './brains/sample';
+

--- a/apps/llm-client/test/client.test.ts
+++ b/apps/llm-client/test/client.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test, vi } from 'vitest';
+import { WebSocketServer } from 'ws';
+import type WebSocket from 'ws';
+import type { AddressInfo } from 'node:net';
+import type { ClientCommand } from '@snail/protocol';
+import {
+  LLMGameClient,
+  type LLMGameBrain,
+  type LobbyStateMessage,
+  type RoomStateMessage,
+  type StateSnapshotMessage,
+} from '../src/client';
+import {
+  GrassLayer,
+  Structure,
+  TerrainType,
+  WaterLayer,
+} from '@snail/protocol';
+
+async function waitFor(predicate: () => boolean, timeout = 1000): Promise<void> {
+  const start = Date.now();
+  return new Promise<void>((resolve, reject) => {
+    const tick = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - start > timeout) {
+        reject(new Error('Timed out waiting for condition.'));
+        return;
+      }
+      setTimeout(tick, 5);
+    };
+    tick();
+  });
+}
+
+describe('LLMGameClient', () => {
+  test('joins, readies after lobby, and forwards brain moves', async () => {
+    const server = new WebSocketServer({ port: 0 });
+    const address = server.address() as AddressInfo;
+    const url = `ws://127.0.0.1:${address.port}`;
+
+    const commands: ClientCommand[] = [];
+    let lobbyDelivered = false;
+
+    const brain: LLMGameBrain = {
+      async onLobbyState(_state, ctx) {
+        ctx.setReady(true);
+      },
+      async onState() {
+        return { t: 'Move', dx: 1, dy: 0 } as const;
+      },
+    };
+
+    const lobbySpy = vi.spyOn(brain, 'onLobbyState');
+    const stateSpy = vi.spyOn(brain, 'onState');
+
+    const client = new LLMGameClient({ url, name: 'TestBot', brain });
+
+    const socketPromise = new Promise<WebSocket>((resolve) => {
+      server.once('connection', (socket) => resolve(socket));
+    });
+
+    const connectPromise = client.connect();
+    const socket = await socketPromise;
+
+    socket.on('message', (raw) => {
+      const parsed = JSON.parse(raw.toString()) as ClientCommand;
+      commands.push(parsed);
+      if (parsed.t === 'Join') {
+        setTimeout(() => {
+          lobbyDelivered = true;
+          const lobby: LobbyStateMessage = {
+            t: 'LobbyState',
+            players: [{ name: 'TestBot', ready: false }],
+            started: false,
+          };
+          const room: RoomStateMessage = {
+            t: 'RoomState',
+            map: {
+              width: 1,
+              height: 1,
+              version: 1,
+              moisture: 0,
+              tiles: [
+                {
+                  terrain: TerrainType.Dirt,
+                  water: WaterLayer.None,
+                  grass: GrassLayer.None,
+                  structure: Structure.None,
+                  slime_intensity: 0,
+                },
+              ],
+            },
+            entities: [],
+            params: {
+              terrain: {
+                [TerrainType.Dirt]: {
+                  base_speed: 1,
+                  hydration_cost: 1,
+                  slime_weight: 1,
+                },
+              },
+              moisture: {
+                thresholds: { wet: 1, damp: 0.5, dry: 0.1 },
+                sidewalk_dry_speed: 1,
+                sidewalk_dry_hydration_cost: 1,
+              },
+              slime: {
+                deposit_rate_per_step: 1,
+                speed_bonus_max: 1,
+                hydration_save_max: 1,
+                decay_per_tick: {},
+              },
+              unit_worker: { carry_capacity: 1, hydration_max: 1 },
+              colony: {
+                build_cost: { biomass: 1, water: 1 },
+                build_time_seconds: 1,
+              },
+              upkeep: {
+                interval_seconds: 1,
+                base: { water: 1, biomass: 1 },
+                colony: { water: 1, biomass: 1 },
+                aura: {
+                  radius: 1,
+                  slime_decay_multiplier: 1,
+                  hydration_cost_hard_multiplier: 1,
+                  speed_bonus: 1,
+                  production_time_multiplier: 1,
+                },
+                dormant_collapse_seconds: 60,
+              },
+              goal: {
+                type: 'Test',
+                colonies_required: 1,
+                sustain_minutes: 1,
+                active_min_stock_any: 0,
+              },
+              simulation: { tick_rate_hz: 1, order: [] },
+              resources: { biomass: 0, water: 0 },
+            },
+          };
+          const state: StateSnapshotMessage = {
+            t: 'State',
+            entities: [],
+          };
+          socket.send(JSON.stringify(lobby));
+          socket.send(JSON.stringify(room));
+          socket.send(JSON.stringify(state));
+        }, 5);
+      }
+    });
+
+    await connectPromise;
+
+    await waitFor(() => commands.some((command) => command.t === 'Join'));
+    await waitFor(() => commands.some((command) => command.t === 'SetReady'));
+
+    expect(lobbyDelivered).toBe(true);
+    expect(lobbySpy).toHaveBeenCalled();
+
+    const joinIndex = commands.findIndex((command) => command.t === 'Join');
+    const readyIndex = commands.findIndex((command) => command.t === 'SetReady');
+    expect(joinIndex).toBeGreaterThan(-1);
+    expect(readyIndex).toBeGreaterThan(joinIndex);
+
+    const readyCommand = commands[readyIndex];
+    expect(readyCommand).toMatchObject({ t: 'SetReady', ready: true });
+
+    await waitFor(() => commands.some((command) => command.t === 'Move'));
+    expect(stateSpy).toHaveBeenCalled();
+
+    const moveIndex = commands.findIndex((command) => command.t === 'Move');
+    expect(moveIndex).toBeGreaterThan(readyIndex);
+    expect(commands[moveIndex]).toMatchObject({ t: 'Move', dx: 1, dy: 0 });
+
+    client.close();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+});
+

--- a/apps/llm-client/tsconfig.json
+++ b/apps/llm-client/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "test"]
+}


### PR DESCRIPTION
## Summary
- add the @snail/llm-client workspace with a Node-oriented LLMGameClient wrapper and exports
- provide a scripted sample brain plus a CLI for local automation runs
- document usage and add vitest coverage for the join/ready/move workflow

## Testing
- `pnpm --filter @snail/llm-client test`


------
https://chatgpt.com/codex/tasks/task_e_68cdcb0ed4f48328a613d7a88449f057