### PR TITLE
feat(llm-client): improve url normalization

### DIFF
--- a/apps/llm-client/README.md
+++ b/apps/llm-client/README.md
@@ -6,7 +6,7 @@ state updates.
 
 ## Features
 
-- Normalises SnailColony WebSocket URLs and sends the required `Join`/`SetReady`/`Move` commands.
+- Normalises SnailColony WebSocket URLs (defaulting to `ws://` and appending `/ws` only when no path is supplied) and sends the required `Join`/`SetReady`/`Move` commands.
 - Emits typed callbacks (`LobbyState`, `RoomState`, `State`) for custom AI integrations.
 - Ships with a small scripted brain and CLI runner for local experimentation.
 
@@ -39,6 +39,9 @@ client.onLobbyState((lobby) => {
 
 await client.connect();
 ```
+
+> **Custom endpoints:** Pass a full WebSocket URL when targeting anything other than the default `/ws` path (for example, `wss://colony.example.com/private/ws?token=abc`).
+> Bare hostnames such as `localhost:3000` are automatically treated as `ws://localhost:3000/ws`.
 
 Implement the `LLMGameBrain` interface to supply your own decision making. Return `Move` commands
 from `onState` or call `context.sendCommand` for direct control.

--- a/apps/llm-client/src/client.ts
+++ b/apps/llm-client/src/client.ts
@@ -30,7 +30,7 @@ export interface LLMGameBrain {
 
 export interface LLMGameClientOptions {
   /**
-   * WebSocket endpoint. If the protocol is omitted, `ws://` is assumed and `/ws` is appended when missing.
+   * WebSocket endpoint. If the protocol is omitted, `ws://` is assumed and `/ws` is only appended when no path is provided.
    */
   url: string;
   /**
@@ -66,15 +66,20 @@ export interface LLMGameClientOptions {
   };
 }
 
-function normalizeUrl(url: string): string {
-  let target = url.trim();
-  if (!target.includes('://')) {
-    target = `ws://${target}`;
+export function normalizeUrl(url: string): string {
+  const trimmed = url.trim();
+  const hasProtocol = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(trimmed);
+  const target = new URL(hasProtocol ? trimmed : `ws://${trimmed}`);
+
+  if (!target.protocol) {
+    target.protocol = 'ws:';
   }
-  if (!target.endsWith('/ws')) {
-    target = target.replace(/\/?$/, '/ws');
+
+  if (target.pathname === '' || target.pathname === '/') {
+    target.pathname = '/ws';
   }
-  return target;
+
+  return target.toString();
 }
 
 export class LLMGameClient {

--- a/apps/llm-client/test/client.test.ts
+++ b/apps/llm-client/test/client.test.ts
@@ -9,6 +9,7 @@ import {
   type LobbyStateMessage,
   type RoomStateMessage,
   type StateSnapshotMessage,
+  normalizeUrl,
 } from '../src/client';
 import {
   GrassLayer,
@@ -34,6 +35,22 @@ async function waitFor(predicate: () => boolean, timeout = 1000): Promise<void> 
     tick();
   });
 }
+
+describe('normalizeUrl', () => {
+  test('defaults to ws:// and appends /ws for bare hostnames', () => {
+    expect(normalizeUrl('localhost:3000')).toBe('ws://localhost:3000/ws');
+  });
+
+  test('preserves fully-qualified URLs with custom paths', () => {
+    const input = 'wss://snail.example.com/custom/path?foo=bar#stats';
+    expect(normalizeUrl(input)).toBe(input);
+  });
+
+  test('leaves existing /ws endpoints with query parameters untouched', () => {
+    const input = 'wss://snail.example.com/ws?token=abc123';
+    expect(normalizeUrl(input)).toBe(input);
+  });
+});
 
 describe('LLMGameClient', () => {
   test('joins, readies after lobby, and forwards brain moves', async () => {


### PR DESCRIPTION
## Summary
- update the llm client WebSocket URL normalizer to rely on the URL parser, defaulting to ws:// and only appending /ws when no path is present
- add unit tests covering bare hostnames, fully-qualified endpoints, and /ws URLs with query strings
- document how to supply custom endpoints and clarify the new normalization behaviour

## Testing
- pnpm --filter @snail/llm-client test

------
https://chatgpt.com/codex/tasks/task_e_68cddba91d7483288c7627b01d7901ff